### PR TITLE
chore: update readme according to current workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In order to satisfy our review process, please follow these steps:
 3. Commit the changes following [Commit guidelines](./docs/COMMITS.md)
 4. Open a new pull request
 5. Wait until the pull request has at least 1 approval (enforced by branch protection)
-6. Add the codesandbox link to the session exercise which was generated with `githubbox`. Don't forget to correct the branchname from your feature branch to `main`.
+6. Add the codesandbox link to the session exercise which was generated with `githubbox` (→ change `github.com` to `githubbox.com` in your browser bar). Don't forget to correct the branchname from your feature branch to `main`.
 
 Example: https://codesandbox.io/s/github/neuefische/web-exercises/tree/main/sessions/example/exercise-01
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In order to satisfy our review process, please follow these steps:
 3. Commit the changes following [Commit guidelines](./docs/COMMITS.md)
 4. Open a new pull request
 5. Wait until the pull request has at least 1 approval (enforced by branch protection)
-6. Add the Codesandbox link to the session exercise (This URL will generate a sandbox from the current main)
+6. Add the codesandbox link to the session exercise which was generated with `githubbox`. Don't forget to correct the branchname from your feature branch to `main`.
 
 Example: https://codesandbox.io/s/github/neuefische/web-exercises/tree/main/sessions/example/exercise-01
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ In order to satisfy our review process, please follow these steps:
    - Option 2: Download an existing codesandbox (see screenshot below)
 3. Commit the changes following [Commit guidelines](./docs/COMMITS.md)
 4. Open a new pull request
-5. Wait until the pull request has at least 2 approvals (enforced by branch protection)
+5. Wait until the pull request has at least 1 approval (enforced by branch protection)
 6. Add the GitHubBox link to the session exercise (This URL will generate a sandbox from the current main)
 
-Example: https://githubbox.com/neuefische/web-exercises/tree/main/sessions/example
+Example: https://codesandbox.io/s/github/neuefische/web-exercises/tree/main/sessions/example/exercise-01
 
 ![Export Codesandbox](docs/resources/codesandbox-export.png)
 
@@ -73,7 +73,7 @@ Since we generate the exercises from the GitHub folder, we don't have to update 
 2. Add new solutions in designated folder in codesandbox
 3. Add solutions with suffix `(solution 01)`
 
-> Each exercise should have two independent solutions.
+> Each exercise should have one independent solution.
 
 Example: https://codesandbox.io/dashboard/all/sessions/example
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ These exercises are tailored as templates for codesandbox
 
 <!-- toc -->
 
-- [Generate Codesandbox from GitHub](#generate-codesandbox-from-github)
-- [Adding new exercises](#adding-new-exercises)
-- [Review new or changed exercises](#review-new-or-changed-exercises)
-- [Update exercises](#update-exercises)
-- [OPTIONAL: Local development](#optional-local-development)
-- [OPTIONAL: Import project to Codesandbox](#optional-import-project-to-codesandbox)
+- [web exercises](#web-exercises)
+  - [Generate Codesandbox from GitHub](#generate-codesandbox-from-github)
+  - [Adding new exercises](#adding-new-exercises)
+  - [Review new or changed exercises](#review-new-or-changed-exercises)
+  - [Update exercises](#update-exercises)
+  - [OPTIONAL: Local development](#optional-local-development)
+  - [OPTIONAL: Import project to Codesandbox](#optional-import-project-to-codesandbox)
 
 <!-- tocstop -->
 
@@ -44,7 +45,7 @@ In order to satisfy our review process, please follow these steps:
 3. Commit the changes following [Commit guidelines](./docs/COMMITS.md)
 4. Open a new pull request
 5. Wait until the pull request has at least 1 approval (enforced by branch protection)
-6. Add the GitHubBox link to the session exercise (This URL will generate a sandbox from the current main)
+6. Add the Codesandbox link to the session exercise (This URL will generate a sandbox from the current main)
 
 Example: https://codesandbox.io/s/github/neuefische/web-exercises/tree/main/sessions/example/exercise-01
 


### PR DESCRIPTION
- change example link for generating codesandbox from main
- update workflow: 1 approval + solution is sufficient instead of 2