### PR TITLE
feat(exercise): a11y form exercise

### DIFF
--- a/sessions/html-forms/Finding-a11y-errors/.eslintrc.json
+++ b/sessions/html-forms/Finding-a11y-errors/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["plugin:react/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react", "@typescript-eslint", "prettier"],
+  "rules": {
+    "no-unused-vars": 0,
+    "react/prop-types": 0,
+    "react/react-in-jsx-scope": 0,
+    "object-curly-spacing": [1, "always"],
+    "comma-dangle": [1, "never"]
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/sessions/html-forms/Finding-a11y-errors/.prettierrc.json
+++ b/sessions/html-forms/Finding-a11y-errors/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "trailingComma": "all",
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "bracketSpacing": false,
+  "arrowParens": "avoid"
+}

--- a/sessions/html-forms/Finding-a11y-errors/.stylelintrc.json
+++ b/sessions/html-forms/Finding-a11y-errors/.stylelintrc.json
@@ -1,0 +1,26 @@
+{
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-prettier",
+    "stylelint-config-styled-components",
+    "stylelint-config-property-sort-order-smacss"
+  ],
+  "plugins": ["stylelint-order", "stylelint-a11y"],
+  "processors": ["stylelint-processor-styled-components"],
+  "rules": {
+    "order/order": ["custom-properties", "declarations"],
+    "selector-type-case": [
+      "lower",
+      {
+        "ignoreTypes": ["/^\\$\\w+/"]
+      }
+    ],
+    "value-keyword-case": ["lower", {"ignoreKeywords": ["dummyValue"]}],
+    "selector-type-no-unknown": [
+      true,
+      {
+        "ignoreTypes": ["/^\\$\\w+/"]
+      }
+    ]
+  }
+}

--- a/sessions/html-forms/Finding-a11y-errors/README.md
+++ b/sessions/html-forms/Finding-a11y-errors/README.md
@@ -4,4 +4,17 @@ This Codesandbox offers a form where the user can submit some information.
 
 Unfortunately, the form is not accessible because there are some issues in the HTML.
 
+## Task:
+
 Switch to the index.html file and make the form accessible!
+
+## Questions to guide you:
+
+- How do you connect a form with its headline?
+- How do you link a description to a specific <fieldset> element?
+- Do all interactive fields have their own label?
+- Are all labels linked to their interactive fields with the help of the correct attributes?
+- Does this connections works correctly?
+  - To check this, go to your browser and click on the label; the corresponding input field should now be focused.
+  - If not, did we make a spelling mistake?
+- Do we need the given placeholder?

--- a/sessions/html-forms/Finding-a11y-errors/README.md
+++ b/sessions/html-forms/Finding-a11y-errors/README.md
@@ -1,0 +1,7 @@
+# Forms and A11y
+
+This Codesandbox offers a form where the user can submit some information.
+
+Unfortunately, the form is not accessible because there are some issues in the HTML.
+
+Switch to the index.html file and make the form accessible!

--- a/sessions/html-forms/Finding-a11y-errors/css/styles.css
+++ b/sessions/html-forms/Finding-a11y-errors/css/styles.css
@@ -1,0 +1,29 @@
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+body {
+	margin: 20px auto;
+	max-width: 350px;
+}
+
+form * {
+	display: grid;
+	margin-top: 10px;
+}
+
+button {
+	margin-top: 0.5rem;
+}
+
+legend {
+	background-color: black;
+	color: white;
+	padding: 0.2rem;
+}
+
+input[type='color'] {
+	margin: auto;
+}

--- a/sessions/html-forms/Finding-a11y-errors/index.html
+++ b/sessions/html-forms/Finding-a11y-errors/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+		<title>Forms and A11y</title>
+		<link rel="stylesheet" href="./css/styles.css" />
+	</head>
+	<body>
+		<section>
+			<h1 class="title">Understanding A11y in Forms</h1>
+			<p id="description">Please let us know how we can support you with a11y issues.</p>
+
+			<form for="title">
+				<fieldset>
+					<legend>Enter your information</legend>
+					<label aria-describedby="name-input">Name:</label>
+					<input id="name-Input" type="text" name="name" />
+					<label aria-describedby="age-input">Age:</label>
+					<input id="age-Input" type="text" name="age" />
+					<label aria-describedby="color-input">Color you cannot see:</label>
+					<input id="color-Input" type="color" name="color" />
+					<textarea rows="7" placeholder="Leave us a message..."></textarea>
+					<button type="submit">Submit</button>
+				</fieldset>
+			</form>
+		</section>
+	</body>
+</html>

--- a/sessions/html-forms/Finding-a11y-errors/package.json
+++ b/sessions/html-forms/Finding-a11y-errors/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "finding-a11y-errors",
+  "version": "1.0.0",
+  "description": "Exercise for A11y in Forms",
+  "main": "index.html"
+}

--- a/sessions/html-forms/Finding-a11y-errors/sandbox.config.json
+++ b/sessions/html-forms/Finding-a11y-errors/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}


### PR DESCRIPTION
The focus of this exercise is a11y in a form.

Students need to find and fix accessibility issues in the HTML file.

Any comment is appreciated as well as suggestions what errors we could add ;)

You can find the [start as a Codesandbox here](https://codesandbox.io/s/github/neuefische/web-exercises/tree/feat/html-forms-a11y-exercise/sessions/html-forms/Finding-a11y-errors?file=/README.md).

List of issues:
- `h1` has `class` instead of `id`
- `form` needs `aria-labelledby` instead of `for`
- `fieldset`: `aria-describedby` is missing
- `textarea`: `label` is missing
- `input`s: `id`s do not match with their `labels`

This exercise corresponds with neuefische/web-curriculum-new-format#14.