### PR TITLE
feat(recap-project-2): character count demo

### DIFF
--- a/sessions/recap-project-2/character-count-example/.eslintrc.json
+++ b/sessions/recap-project-2/character-count-example/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["plugin:react/recommended", "xo"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react", "@typescript-eslint", "prettier"],
+  "rules": {
+    "no-unused-vars": 0,
+    "react/prop-types": 0,
+    "react/react-in-jsx-scope": 0
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/sessions/recap-project-2/character-count-example/.prettierrc.json
+++ b/sessions/recap-project-2/character-count-example/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "trailingComma": "all",
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "bracketSpacing": false,
+  "arrowParens": "avoid"
+}

--- a/sessions/recap-project-2/character-count-example/.stylelintrc.json
+++ b/sessions/recap-project-2/character-count-example/.stylelintrc.json
@@ -1,0 +1,26 @@
+{
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-prettier",
+    "stylelint-config-styled-components",
+    "stylelint-config-property-sort-order-smacss"
+  ],
+  "plugins": ["stylelint-order", "stylelint-a11y"],
+  "processors": ["stylelint-processor-styled-components"],
+  "rules": {
+    "order/order": ["custom-properties", "declarations"],
+    "selector-type-case": [
+      "lower",
+      {
+        "ignoreTypes": ["/^\\$\\w+/"]
+      }
+    ],
+    "value-keyword-case": ["lower", {"ignoreKeywords": ["dummyValue"]}],
+    "selector-type-no-unknown": [
+      true,
+      {
+        "ignoreTypes": ["/^\\$\\w+/"]
+      }
+    ]
+  }
+}

--- a/sessions/recap-project-2/character-count-example/css/styles.css
+++ b/sessions/recap-project-2/character-count-example/css/styles.css
@@ -1,32 +1,28 @@
 *,
 *::before,
 *::after {
-  box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
-    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+	margin: 0;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+		'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
 .form {
-  margin: 20px auto;
-  max-width: 320px;
-  display: grid;
-  justify-items: start;
-  gap: 12px;
+	margin: 20px auto;
+	max-width: 320px;
+	display: grid;
+	justify-items: start;
+	gap: 12px;
 }
 
 .form__label {
-  display: block;
+	display: block;
 }
 
 .form__character-count {
-  font-size: inherit;
-  color: #666;
-}
-
-.hidden {
-  display: none;
+	font-size: inherit;
+	color: #666;
 }

--- a/sessions/recap-project-2/character-count-example/css/styles.css
+++ b/sessions/recap-project-2/character-count-example/css/styles.css
@@ -1,0 +1,32 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}
+
+.form {
+  margin: 20px auto;
+  max-width: 320px;
+  display: grid;
+  justify-items: start;
+  gap: 12px;
+}
+
+.form__label {
+  display: block;
+}
+
+.form__character-count {
+  font-size: inherit;
+  color: #666;
+}
+
+.hidden {
+  display: none;
+}

--- a/sessions/recap-project-2/character-count-example/index.html
+++ b/sessions/recap-project-2/character-count-example/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Character Count Example</title>
+    <link rel="stylesheet" href="./css/styles.css" />
+  </head>
+  <body>
+    <form class="form">
+      <h1>Fix me</h1>
+      <label class="form__label" for="question">Question:</label>
+      <textarea
+        maxlength="200"
+        data-js="question"
+        name="question"
+        id="question"
+        cols="24"
+        rows="3"
+      ></textarea>
+      <small data-js="characterCount" class="form__character-count"
+        >(<span data-js="amountLeft"></span> characters left)</small
+      >
+      <button>Create card</button>
+    </form>
+  </body>
+  <script src="./js/index.js"></script>
+</html>

--- a/sessions/recap-project-2/character-count-example/index.html
+++ b/sessions/recap-project-2/character-count-example/index.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <title>Character Count Example</title>
-    <link rel="stylesheet" href="./css/styles.css" />
-  </head>
-  <body>
-    <form class="form">
-      <h1>Fix me</h1>
-      <label class="form__label" for="question">Question:</label>
-      <textarea
-        maxlength="200"
-        data-js="question"
-        name="question"
-        id="question"
-        cols="24"
-        rows="3"
-      ></textarea>
-      <small data-js="characterCount" class="form__character-count"
-        >(<span data-js="amountLeft"></span> characters left)</small
-      >
-      <button>Create card</button>
-    </form>
-  </body>
-  <script src="./js/index.js"></script>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+		<title>Character Count Example</title>
+		<link rel="stylesheet" href="./css/styles.css" />
+		<script src="./js/index.js" defer></script>
+	</head>
+	<body>
+		<form class="form">
+			<h1>Write and Wonder</h1>
+			<label class="form__label" for="personal-message">Personal Message:</label>
+			<textarea
+				maxlength="200"
+				data-js="personalMessage"
+				name="personalMessage"
+				id="personal-message"
+				cols="24"
+				rows="3"
+			></textarea>
+			<small class="form__character-count"
+				>(<span data-js="amountLeft"></span> characters left)</small
+			>
+			<button>Submit message</button>
+		</form>
+	</body>
 </html>

--- a/sessions/recap-project-2/character-count-example/js/index.js
+++ b/sessions/recap-project-2/character-count-example/js/index.js
@@ -1,8 +1,8 @@
 console.clear();
 
-const questionElement = document.querySelector('[data-js="question"]');
+const questionElement = document.querySelector('[data-js="personalMessage"]');
 const amountLeft = document.querySelector('[data-js="amountLeft"]');
-const maxLength = questionElement.getAttribute('maxLength');
+const maxLength = questionElement.getAttribute('maxlength');
 
 const updateAmountLeft = value => {
 	amountLeft.innerText = value;

--- a/sessions/recap-project-2/character-count-example/js/index.js
+++ b/sessions/recap-project-2/character-count-example/js/index.js
@@ -1,0 +1,15 @@
+console.clear();
+
+const questionElement = document.querySelector('[data-js="question"]');
+const amountLeft = document.querySelector('[data-js="amountLeft"]');
+const maxLength = questionElement.getAttribute('maxLength');
+
+const updateAmountLeft = value => {
+	amountLeft.innerText = value;
+};
+
+updateAmountLeft(maxLength);
+
+questionElement.addEventListener('input', () => {
+	updateAmountLeft(maxLength - questionElement.value.length);
+});

--- a/sessions/recap-project-2/character-count-example/package.json
+++ b/sessions/recap-project-2/character-count-example/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "character-count-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.html",
+  "keywords": []
+}

--- a/sessions/recap-project-2/character-count-example/sandbox.config.json
+++ b/sessions/recap-project-2/character-count-example/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}


### PR DESCRIPTION
One task of the Recap project 2 is to implement a counter of left characters while using an input field.

This codesandbox is meant as a demo we can provide to the students. 

## Links
- [Codesandbox](https://codesandbox.io/s/github/neuefische/web-exercises/tree/feature/recap-project-2-demo-counter/sessions/recap-project-2/character-count-example)
- [Code](https://github.com/neuefische/web-exercises/tree/feature/recap-project-2-demo-counter/sessions/recap-project-2/character-count-example)
- [Corresponding Task in the Draft PR #114](https://github.com/neuefische/web-curriculum-new-format/blob/recap-project-2/sessions/recap-project-2/recap-project-2.md#4-form-field-text-counter)

## Questions
- I tried to use an `onChange` event, but was not able to get it running. Do we get a problem using the `input` event somehow?
- Do we need a readme here as well?

## Belongs to
- neuefische/web-curriculum-new-format#26
- neuefische/web-curriculum-new-format#114