### PR TITLE
chore(js-template): update static-html-css-js template

### DIFF
--- a/templates/static-html-css-js/index.html
+++ b/templates/static-html-css-js/index.html
@@ -5,9 +5,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 		<title>HTML & CSS & JS</title>
 		<link rel="stylesheet" href="./css/styles.css" />
+		<script src="./js/index.js" defer></script>
 	</head>
 	<body>
 		<h1>Fix me</h1>
 	</body>
-	<script src="./js/index.js"></script>
 </html>


### PR DESCRIPTION
It was agreed as best practice to use a `script` tag for linking the js-file at the beginning of the html-file together with the `defer` attribute.

The `script`was thus moved to the `head` element.