### PR TITLE
feat(templates): add readme files for all templates

### DIFF
--- a/templates/javascript/README.md
+++ b/templates/javascript/README.md
@@ -1,0 +1,17 @@
+# Objects
+
+Objects are everywhere. Let's become confident handling them!
+
+## Task
+
+In this exercise, you will encounter the following tasks:
+
+- assign or add a variable to a value of an object,
+- the variable itself is an object and you need to adjust it.
+
+Please switch to the [index.js](index.js) file to start the exercises. You will find the exact tasks there.
+
+## Notes
+
+- If you want to check whether you solved the tasks correctly, open the "Tests" tab of Codesandbox.
+- You only have to touch the `js/index.js` file.

--- a/templates/react/README.md
+++ b/templates/react/README.md
@@ -1,0 +1,19 @@
+# Fetching the Pokemon API
+
+For now, the pokemon are only fetched when we click the button below. Let's change the code in such a way that our app does this automatically.
+
+## Task
+
+Switch to the [App.js](./src/App.js) file and
+
+1. remove the 'Load Pokemon' button.
+2. fetch pokemon when the app is rendered.
+
+You can use the following hints as guideline:
+
+- The `loadPokemon` function should only be executed when the app is rendered.
+- Don't forget the dependency array!
+
+## Notes
+
+- You only have to touch the `App.js` file.

--- a/templates/static-html-css-js/README.md
+++ b/templates/static-html-css-js/README.md
@@ -1,0 +1,21 @@
+# Handle Form Submit
+
+This codesandbox offers a simple form with three input fields. Let's make it interactive with JS!
+
+## Task
+
+Use JavaScript to react to the form submission.
+
+Log all form data (in object form) into the console in the submit event handler.
+
+You can use the following hints as guideline:
+
+- Hint 1
+- Hint 2
+- ...
+
+Switch to the [index.js](./js/index.js) file and make something great happen!
+
+## Notes
+
+- You only have to touch the `js/index.js` file.

--- a/templates/static-html-css/README.md
+++ b/templates/static-html-css/README.md
@@ -1,0 +1,18 @@
+# My First Website
+
+This codesandbox offers a simple static website. Let's make it more gorgeous with HTML and CSS!
+
+## Task
+
+Build a personal website according to the ![wireframe](). Use the following hints as guidelines:
+
+- Hint 1
+- Hint 2
+- ...
+
+Switch to the [index.html](./index.html) file and make something great happen!
+
+## Notes
+
+- It should not be necessary to change the file xyz.
+- There is no need to do ...

--- a/templates/styled-components/README.md
+++ b/templates/styled-components/README.md
@@ -1,0 +1,19 @@
+# Fetching the Pokemon API
+
+For now, the pokemon are only fetched when we click the button below. Let's change the code in such a way that our app does this automatically.
+
+## Task
+
+Switch to the [App.js](./src/App.js) file and
+
+1. remove the 'Load Pokemon' button.
+2. fetch pokemon when the app is rendered.
+
+You can use the following hints as guideline:
+
+- The `loadPokemon` function should only be executed when the app is rendered.
+- Don't forget the dependency array!
+
+## Notes
+
+- You only have to touch the `App.js` file.


### PR DESCRIPTION
We want to have a `readme.md` in every Codesandbox to explain the tasks of this specific exercise.

I added example readme files for all five templates; each of them contain an example description.

rendered: https://github.com/neuefische/web-exercises/tree/chore/template-readme-files/templates

fixes neuefische/web-curriculum-new-format#123