### PR TITLE
feat: added an alternative demo start/end

### DIFF
--- a/sessions/css-selectors/demo-end_alternative/.eslintrc.json
+++ b/sessions/css-selectors/demo-end_alternative/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["plugin:react/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react", "@typescript-eslint", "prettier"],
+  "rules": {
+    "no-unused-vars": 0,
+    "react/prop-types": 0,
+    "react/react-in-jsx-scope": 0,
+    "object-curly-spacing": [1, "always"],
+    "comma-dangle": [1, "never"]
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/sessions/css-selectors/demo-end_alternative/.prettierrc.json
+++ b/sessions/css-selectors/demo-end_alternative/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "trailingComma": "all",
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "bracketSpacing": false,
+  "arrowParens": "avoid"
+}

--- a/sessions/css-selectors/demo-end_alternative/.stylelintrc.json
+++ b/sessions/css-selectors/demo-end_alternative/.stylelintrc.json
@@ -1,0 +1,26 @@
+{
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-prettier",
+    "stylelint-config-styled-components",
+    "stylelint-config-property-sort-order-smacss"
+  ],
+  "plugins": ["stylelint-order", "stylelint-a11y"],
+  "processors": ["stylelint-processor-styled-components"],
+  "rules": {
+    "order/order": ["custom-properties", "declarations"],
+    "selector-type-case": [
+      "lower",
+      {
+        "ignoreTypes": ["/^\\$\\w+/"]
+      }
+    ],
+    "value-keyword-case": ["lower", {"ignoreKeywords": ["dummyValue"]}],
+    "selector-type-no-unknown": [
+      true,
+      {
+        "ignoreTypes": ["/^\\$\\w+/"]
+      }
+    ]
+  }
+}

--- a/sessions/css-selectors/demo-end_alternative/css/styles.css
+++ b/sessions/css-selectors/demo-end_alternative/css/styles.css
@@ -1,0 +1,146 @@
+/* I am the root pseudo-class. The html type selector and
+I target pretty much the same stuff, but my specificity is 
+higher. I'm frequently used to store global CSS variables. */
+
+:root {
+	/* Color Variables */
+
+	--nemo: #ff4a11;
+	--granite: #252629;
+	--water: #f3f5f9;
+	--foam: #ffffff;
+
+	/* Unit Variables */
+	--gap: 20px;
+}
+
+/* I'm the universal selector. I target EVERYTHING. */
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+
+/* PART 1: I'm a type selector. I target a specific type of element. */
+body {
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+		'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}
+
+h1 {
+	color: var(--nemo);
+	text-shadow: 3px 3px var(--granite);
+}
+
+h1,
+h2 {
+	margin: var(--gap);
+}
+
+h3 {
+	margin-bottom: var(--gap);
+}
+
+a {
+	text-decoration: none;
+}
+
+/* PART 2: I'm a class selector. I correspond with the classes declared as part
+of an HTML tag. Like <section class="main-section">. */
+.main-content {
+	width: 80%;
+	margin: auto;
+}
+
+.main-section {
+	padding: var(--gap);
+	background-color: var(--water);
+	margin-bottom: var(--gap);
+}
+
+.box {
+	width: 100px;
+	height: 100px;
+	text-align: center;
+}
+
+.box--pink {
+	background-color: lightpink;
+}
+
+/* PART 3: I'm an attribute selector. I correspond with the attributes declared 
+as part of HTML tags. */
+
+button[type='button'] {
+	padding: var(--gap);
+}
+
+ul[role='list'] {
+	list-style-type: none;
+}
+
+a[href^='https'] {
+	color: hotpink;
+	padding: 8px;
+	margin: 0 0 8px 0;
+}
+
+/* PART 4: I'm a pseudo-class. I'm  a keyword added to a selector that 
+specifies a special state of the selected element. */
+
+a[href^='https']:hover {
+	background-color: hotpink;
+	color: #fff;
+}
+
+input[type='text']:focus {
+	outline: 2px solid hotpink;
+	border: none;
+	border-radius: 3px;
+}
+
+/* PART 5: I'm a pseudo-element. I'm a keyword added to a selector that lets
+you style a specific part of the selected element. */
+
+p::first-letter {
+	font-size: 32px;
+}
+
+a[href^='https']:before {
+	content: '🍰';
+	margin-right: 8px;
+}
+
+/* PART 6: I'm the ID selector. I shouldn't be used. */
+
+#very-important-text {
+	color: #fff;
+}
+
+/* PART 7: I'm a descendant combinator. I will select all descendants
+of the parent element, but only those descendants that match my type. */
+
+.main-section .text {
+	color: var(--granite);
+	/* This should overwrite the color rule of the ID selector, but because 
+  of its very high specificity, the ID selector rule remains. There is
+  nothing short of using !important that overrules any ID's specificity. */
+}
+
+/* PART 8: I'm a child combinator. I will select all direct children
+of the parent element, but only those children that match my type. */
+
+.main-section > article {
+	padding: var(--gap);
+	background-color: lightpink;
+	border: 4px dotted #fff;
+}
+
+/* PART 9: I'm an adjacent sibling selector. The rules I  declare 
+only count for myself and my adjacent sibling. */
+
+section div + span {
+	color: hotpink;
+}

--- a/sessions/css-selectors/demo-end_alternative/css/styles.css
+++ b/sessions/css-selectors/demo-end_alternative/css/styles.css
@@ -125,8 +125,9 @@ of the parent element, but only those descendants that match my type. */
 .main-section .text {
 	color: var(--granite);
 	/* This should overwrite the color rule of the ID selector, but because 
-  of its very high specificity, the ID selector rule remains. There is
-  nothing short of using !important that overrules any ID's specificity. */
+  of its very high specificity, the ID selector rule remains. The only way to
+  overwrite rules declares inside of an ID selector is to use !important, which
+  we want to avoid. */
 }
 
 /* PART 8: I'm a child combinator. I will select all direct children
@@ -138,7 +139,7 @@ of the parent element, but only those children that match my type. */
 	border: 4px dotted #fff;
 }
 
-/* PART 9: I'm an adjacent sibling selector. The rules I  declare 
+/* PART 9: I'm an adjacent sibling selector. The rules I declare 
 only count for myself and my adjacent sibling. */
 
 section div + span {

--- a/sessions/css-selectors/demo-end_alternative/index.html
+++ b/sessions/css-selectors/demo-end_alternative/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+		<title>HTML & CSS</title>
+		<link rel="stylesheet" href="./css/styles.css" />
+	</head>
+	<body>
+		<h1>CSS Selectors</h1>
+		<h2>Let's make this look a little more interesting.</h2>
+		<main class="main-content">
+			<section class="main-section">
+				<a href="#">I'm a link!</a>
+			</section>
+
+			<section class="main-section">
+				<div class="box box--pink">I'm a box!</div>
+			</section>
+
+			<section class="main-section">
+				<button type="button">I'm a button!</button>
+			</section>
+
+			<section class="main-section">
+				<ul class="cake-list" role="list">
+					<li class="cake-list__item">
+						<a href="https://en.wikipedia.org/wiki/Red_velvet_cake">Red Velvet Cake</a>
+					</li>
+					<li class="cake-list__item">
+						<a href="https://en.wikipedia.org/wiki/Angel_food_cake">Angel Foood Cake</a>
+					</li>
+					<li class="cake-list__item">
+						<a href="https://en.wikipedia.org/wiki/Cheesecake">Cheesecake</a>
+					</li>
+					<li class="cake-list__item">
+						<a href="https://en.wikipedia.org/wiki/Chocolate_cake">Chocolate Cake</a>
+					</li>
+				</ul>
+			</section>
+
+			<section class="main-section">
+				<label for="fav-cake">Your favorite cake: </label
+				><input type="text" id="fav-cake" />
+			</section>
+
+			<section class="main-section">
+				<article>
+					<p class="text">
+						Cakes are desserts typically consisting of a baked mixture of flour, eggs,
+						and milk, and made tastier with chocolate, fruit, or whipped cream.
+					</p>
+					<p class="text" id="very-important-text">Cake is delicious!</p>
+					<p class="text">There is a lot to say about cakes.</p>
+				</article>
+			</section>
+
+			<section class="main-section">
+				<div>
+					Yummy
+					<span>Yummy</span>
+				</div>
+				<span>Yummy</span>
+				<span>Yummy</span>
+			</section>
+		</main>
+	</body>
+</html>

--- a/sessions/css-selectors/demo-end_alternative/package.json
+++ b/sessions/css-selectors/demo-end_alternative/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "css-selectors-demo-end",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.html",
+  "keywords": []
+}

--- a/sessions/css-selectors/demo-end_alternative/sandbox.config.json
+++ b/sessions/css-selectors/demo-end_alternative/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/sessions/css-selectors/demo-start_alternative/.eslintrc.json
+++ b/sessions/css-selectors/demo-start_alternative/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["plugin:react/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react", "@typescript-eslint", "prettier"],
+  "rules": {
+    "no-unused-vars": 0,
+    "react/prop-types": 0,
+    "react/react-in-jsx-scope": 0,
+    "object-curly-spacing": [1, "always"],
+    "comma-dangle": [1, "never"]
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/sessions/css-selectors/demo-start_alternative/.prettierrc.json
+++ b/sessions/css-selectors/demo-start_alternative/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "trailingComma": "all",
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "bracketSpacing": false,
+  "arrowParens": "avoid"
+}

--- a/sessions/css-selectors/demo-start_alternative/.stylelintrc.json
+++ b/sessions/css-selectors/demo-start_alternative/.stylelintrc.json
@@ -1,0 +1,26 @@
+{
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-prettier",
+    "stylelint-config-styled-components",
+    "stylelint-config-property-sort-order-smacss"
+  ],
+  "plugins": ["stylelint-order", "stylelint-a11y"],
+  "processors": ["stylelint-processor-styled-components"],
+  "rules": {
+    "order/order": ["custom-properties", "declarations"],
+    "selector-type-case": [
+      "lower",
+      {
+        "ignoreTypes": ["/^\\$\\w+/"]
+      }
+    ],
+    "value-keyword-case": ["lower", {"ignoreKeywords": ["dummyValue"]}],
+    "selector-type-no-unknown": [
+      true,
+      {
+        "ignoreTypes": ["/^\\$\\w+/"]
+      }
+    ]
+  }
+}

--- a/sessions/css-selectors/demo-start_alternative/css/styles.css
+++ b/sessions/css-selectors/demo-start_alternative/css/styles.css
@@ -1,0 +1,115 @@
+/* I am the root pseudo-class. The html type selector and
+I target pretty much the same stuff, but my specificity is 
+higher. I'm frequently used to store global CSS variables. */
+
+:root {
+	/* Color Variables */
+
+	--nemo: #ff4a11;
+	--granite: #252629;
+	--water: #f3f5f9;
+	--foam: #ffffff;
+
+	/* Unit Variables */
+	--gap: 20px;
+}
+
+/* I'm the universal selector. I target EVERYTHING. */
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+
+/* PART 1: I'm a type selector. I target a specific type of element. */
+body {
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+		'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}
+
+h1 {
+	color: var(--nemo);
+	text-shadow: 3px 3px var(--granite);
+}
+
+h1,
+h2 {
+}
+
+h3 {
+}
+
+a {
+}
+
+/* PART 2: I'm a class selector. I correspond with the classes declared as part
+of an HTML tag. Like <section class="main-section">. */
+.main-content {
+}
+
+.main-section {
+}
+
+.box {
+}
+
+.box--pink {
+}
+
+/* PART 3: I'm an attribute selector. I correspond with the attributes declared 
+as part of HTML tags. */
+
+button[type='button'] {
+}
+
+ul[role='list'] {
+}
+
+a[href^='https'] {
+}
+
+/* PART 4: I'm a pseudo-class. I'm  a keyword added to a selector that 
+specifies a special state of the selected element. */
+
+a[href^='https']:hover {
+}
+
+input[type='text']:focus {
+}
+
+/* PART 5: I'm a pseudo-element. I'm a keyword added to a selector that lets
+you style a specific part of the selected element. */
+
+p::first-letter {
+}
+
+a[href^='https']:before {
+}
+
+/* PART 6: I'm the ID selector. I shouldn't be used. */
+
+#very-important-text {
+}
+
+/* PART 7: I'm a descendant combinator. I will select all descendants
+of the parent element, but only those descendants that match my type. */
+
+.main-section .text {
+	/* This should overwrite the color rule of the ID selector, but because 
+  of its very high specificity, the ID selector rule remains. There is
+  nothing short of using !important that overrules any ID's specificity. */
+}
+
+/* PART 8: I'm a child combinator. I will select all direct children
+of the parent element, but only those children that match my type. */
+
+.main-section > article {
+}
+
+/* PART 9: I'm an adjacent sibling selector. The rules I  declare 
+only count for myself and my adjacent sibling. */
+
+section div + span {
+}

--- a/sessions/css-selectors/demo-start_alternative/css/styles.css
+++ b/sessions/css-selectors/demo-start_alternative/css/styles.css
@@ -98,8 +98,9 @@ of the parent element, but only those descendants that match my type. */
 
 .main-section .text {
 	/* This should overwrite the color rule of the ID selector, but because 
-  of its very high specificity, the ID selector rule remains. There is
-  nothing short of using !important that overrules any ID's specificity. */
+  of its very high specificity, the ID selector rule remains. The only way to
+  overwrite rules declares inside of an ID selector is to use !important, which
+  we want to avoid. */
 }
 
 /* PART 8: I'm a child combinator. I will select all direct children
@@ -108,7 +109,7 @@ of the parent element, but only those children that match my type. */
 .main-section > article {
 }
 
-/* PART 9: I'm an adjacent sibling selector. The rules I  declare 
+/* PART 9: I'm an adjacent sibling selector. The rules I declare 
 only count for myself and my adjacent sibling. */
 
 section div + span {

--- a/sessions/css-selectors/demo-start_alternative/index.html
+++ b/sessions/css-selectors/demo-start_alternative/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+		<title>HTML & CSS</title>
+		<link rel="stylesheet" href="./css/styles.css" />
+	</head>
+	<body>
+		<h1>CSS Selectors</h1>
+		<h2>Let's make this look a little more interesting.</h2>
+		<main class="main-content">
+			<section class="main-section">
+				<a href="#">I'm a link!</a>
+			</section>
+
+			<section class="main-section">
+				<div class="box box--pink">I'm a box!</div>
+			</section>
+
+			<section class="main-section">
+				<button type="button">I'm a button!</button>
+			</section>
+
+			<section class="main-section">
+				<ul class="cake-list" role="list">
+					<li class="cake-list__item">
+						<a href="https://en.wikipedia.org/wiki/Red_velvet_cake">Red Velvet Cake</a>
+					</li>
+					<li class="cake-list__item">
+						<a href="https://en.wikipedia.org/wiki/Angel_food_cake">Angel Foood Cake</a>
+					</li>
+					<li class="cake-list__item">
+						<a href="https://en.wikipedia.org/wiki/Cheesecake">Cheesecake</a>
+					</li>
+					<li class="cake-list__item">
+						<a href="https://en.wikipedia.org/wiki/Chocolate_cake">Chocolate Cake</a>
+					</li>
+				</ul>
+			</section>
+
+			<section class="main-section">
+				<label for="fav-cake">Your favorite cake: </label
+				><input type="text" id="fav-cake" />
+			</section>
+
+			<section class="main-section">
+				<article>
+					<p class="text">
+						Cakes are desserts typically consisting of a baked mixture of flour, eggs,
+						and milk, and made tastier with chocolate, fruit, or whipped cream.
+					</p>
+					<p class="text" id="very-important-text">Cake is delicious!</p>
+					<p class="text">There is a lot to say about cakes.</p>
+				</article>
+			</section>
+
+			<section class="main-section">
+				<div>
+					Yummy
+					<span>Yummy</span>
+				</div>
+				<span>Yummy</span>
+				<span>Yummy</span>
+			</section>
+		</main>
+	</body>
+</html>

--- a/sessions/css-selectors/demo-start_alternative/package.json
+++ b/sessions/css-selectors/demo-start_alternative/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "css-selectors-demo-end",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.html",
+  "keywords": []
+}

--- a/sessions/css-selectors/demo-start_alternative/sandbox.config.json
+++ b/sessions/css-selectors/demo-start_alternative/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}


### PR DESCRIPTION
An alternative demo for the CSS selectors session.

rendered: https://github.com/neuefische/web-exercises/tree/feature/css-selectors-alternative-demo/sessions/css-selectors

fixes neuefische/web-curriculum-new-format#117