### PR TITLE
refactor(js-forms-2): replace innerHTML with createElement

### DIFF
--- a/sessions/js-forms-2/demo-end/js/index.js
+++ b/sessions/js-forms-2/demo-end/js/index.js
@@ -8,15 +8,31 @@ function addStorageEntry(title, email, password) {
 	const entryElement = document.createElement('li');
 	entryElement.className = 'storage__entry';
 
-	entryElement.innerHTML = `
-		<h3	class="storage__title">${title}</h3>
-		<dl class="storage__credentials">
-			<dt>Email:</dt>
-			<dd>${email}</dd>
-			<dt>Password:</dt>
-			<dd>${password}</dd>
-		</dl>
-	`;
+	const headline = document.createElement('h3');
+	headline.className = 'storage__title';
+	headline.textContent = title;
+	entryElement.append(headline);
+
+	const descriptionList = document.createElement('dl');
+	descriptionList.className = 'storage__credentials';
+
+	const descriptionTermOne = document.createElement('dt');
+	descriptionTermOne.textContent = 'Email:';
+	descriptionList.append(descriptionTermOne);
+
+	const descriptionDetailsOne = document.createElement('dd');
+	descriptionDetailsOne.textContent = email;
+	descriptionList.append(descriptionDetailsOne);
+
+	const descriptionTermTwo = document.createElement('dt');
+	descriptionTermTwo.textContent = 'Password:';
+	descriptionList.append(descriptionTermTwo);
+
+	const descriptionDetailsTwo = document.createElement('dd');
+	descriptionDetailsTwo.textContent = password;
+	descriptionList.append(descriptionDetailsTwo);
+
+	entryElement.append(descriptionList);
 
 	storage.append(entryElement);
 }

--- a/sessions/js-forms-2/demo-end/js/index.js
+++ b/sessions/js-forms-2/demo-end/js/index.js
@@ -16,21 +16,21 @@ function addStorageEntry(title, email, password) {
 	const descriptionList = document.createElement('dl');
 	descriptionList.className = 'storage__credentials';
 
-	const descriptionTermOne = document.createElement('dt');
-	descriptionTermOne.textContent = 'Email:';
-	descriptionList.append(descriptionTermOne);
+	const descriptionTermEmail = document.createElement('dt');
+	descriptionTermEmail.textContent = 'Email:';
+	descriptionList.append(descriptionTermEmail);
 
-	const descriptionDetailsOne = document.createElement('dd');
-	descriptionDetailsOne.textContent = email;
-	descriptionList.append(descriptionDetailsOne);
+	const descriptionDetailsEmail = document.createElement('dd');
+	descriptionDetailsEmail.textContent = email;
+	descriptionList.append(descriptionDetailsEmail);
 
-	const descriptionTermTwo = document.createElement('dt');
-	descriptionTermTwo.textContent = 'Password:';
-	descriptionList.append(descriptionTermTwo);
+	const descriptionTermPassword = document.createElement('dt');
+	descriptionTermPassword.textContent = 'Password:';
+	descriptionList.append(descriptionTermPassword);
 
-	const descriptionDetailsTwo = document.createElement('dd');
-	descriptionDetailsTwo.textContent = password;
-	descriptionList.append(descriptionDetailsTwo);
+	const descriptionDetailsPassword = document.createElement('dd');
+	descriptionDetailsPassword.textContent = password;
+	descriptionList.append(descriptionDetailsPassword);
 
 	entry.append(descriptionList);
 

--- a/sessions/js-forms-2/demo-end/js/index.js
+++ b/sessions/js-forms-2/demo-end/js/index.js
@@ -11,7 +11,7 @@ function addStorageEntry(title, email, password) {
 	const headline = document.createElement('h3');
 	headline.className = 'storage__title';
 	headline.textContent = title;
-	entryElement.append(headline);
+	entry.append(headline);
 
 	const descriptionList = document.createElement('dl');
 	descriptionList.className = 'storage__credentials';

--- a/sessions/js-forms-2/demo-end/js/index.js
+++ b/sessions/js-forms-2/demo-end/js/index.js
@@ -5,8 +5,8 @@ const storage = document.querySelector('[data-js="storage"]');
 const passwordInput = document.querySelector('[data-js="password-input"]');
 
 function addStorageEntry(title, email, password) {
-	const entryElement = document.createElement('li');
-	entryElement.className = 'storage__entry';
+	const entry = document.createElement('li');
+	entry.className = 'storage__entry';
 
 	const headline = document.createElement('h3');
 	headline.className = 'storage__title';

--- a/sessions/js-forms-2/demo-end/js/index.js
+++ b/sessions/js-forms-2/demo-end/js/index.js
@@ -34,7 +34,7 @@ function addStorageEntry(title, email, password) {
 
 	entry.append(descriptionList);
 
-	storage.append(entryElement);
+	storage.append(entry);
 }
 
 function updatePasswordStrength(text) {

--- a/sessions/js-forms-2/demo-end/js/index.js
+++ b/sessions/js-forms-2/demo-end/js/index.js
@@ -32,7 +32,7 @@ function addStorageEntry(title, email, password) {
 	descriptionDetailsTwo.textContent = password;
 	descriptionList.append(descriptionDetailsTwo);
 
-	entryElement.append(descriptionList);
+	entry.append(descriptionList);
 
 	storage.append(entryElement);
 }

--- a/sessions/js-forms-2/demo-start/js/index.js
+++ b/sessions/js-forms-2/demo-start/js/index.js
@@ -8,15 +8,31 @@ function addStorageEntry(title, email, password) {
 	const entryElement = document.createElement('li');
 	entryElement.className = 'storage__entry';
 
-	entryElement.innerHTML = `
-		<h3	class="storage__title">${title}</h3>
-		<dl class="storage__credentials">
-			<dt>Email:</dt>
-			<dd>${email}</dd>
-			<dt>Password:</dt>
-			<dd>${password}</dd>
-		</dl>
-	`;
+	const headline = document.createElement('h3');
+	headline.className = 'storage__title';
+	headline.textContent = title;
+	entryElement.append(headline);
+
+	const descriptionList = document.createElement('dl');
+	descriptionList.className = 'storage__credentials';
+
+	const descriptionTermOne = document.createElement('dt');
+	descriptionTermOne.textContent = 'Email:';
+	descriptionList.append(descriptionTermOne);
+
+	const descriptionDetailsOne = document.createElement('dd');
+	descriptionDetailsOne.textContent = email;
+	descriptionList.append(descriptionDetailsOne);
+
+	const descriptionTermTwo = document.createElement('dt');
+	descriptionTermTwo.textContent = 'Password:';
+	descriptionList.append(descriptionTermTwo);
+
+	const descriptionDetailsTwo = document.createElement('dd');
+	descriptionDetailsTwo.textContent = password;
+	descriptionList.append(descriptionDetailsTwo);
+
+	entryElement.append(descriptionList);
 
 	storage.append(entryElement);
 }

--- a/sessions/js-forms-2/demo-start/js/index.js
+++ b/sessions/js-forms-2/demo-start/js/index.js
@@ -16,21 +16,21 @@ function addStorageEntry(title, email, password) {
 	const descriptionList = document.createElement('dl');
 	descriptionList.className = 'storage__credentials';
 
-	const descriptionTermOne = document.createElement('dt');
-	descriptionTermOne.textContent = 'Email:';
-	descriptionList.append(descriptionTermOne);
+	const descriptionTermEmail = document.createElement('dt');
+	descriptionTermEmail.textContent = 'Email:';
+	descriptionList.append(descriptionTermEmail);
 
-	const descriptionDetailsOne = document.createElement('dd');
-	descriptionDetailsOne.textContent = email;
-	descriptionList.append(descriptionDetailsOne);
+	const descriptionDetailsEmail = document.createElement('dd');
+	descriptionDetailsEmail.textContent = email;
+	descriptionList.append(descriptionDetailsEmail);
 
-	const descriptionTermTwo = document.createElement('dt');
-	descriptionTermTwo.textContent = 'Password:';
-	descriptionList.append(descriptionTermTwo);
+	const descriptionTermPassword = document.createElement('dt');
+	descriptionTermPassword.textContent = 'Password:';
+	descriptionList.append(descriptionTermPassword);
 
-	const descriptionDetailsTwo = document.createElement('dd');
-	descriptionDetailsTwo.textContent = password;
-	descriptionList.append(descriptionDetailsTwo);
+	const descriptionDetailsPassword = document.createElement('dd');
+	descriptionDetailsPassword.textContent = password;
+	descriptionList.append(descriptionDetailsPassword);
 
 	entry.append(descriptionList);
 

--- a/sessions/js-forms-2/demo-start/js/index.js
+++ b/sessions/js-forms-2/demo-start/js/index.js
@@ -11,7 +11,7 @@ function addStorageEntry(title, email, password) {
 	const headline = document.createElement('h3');
 	headline.className = 'storage__title';
 	headline.textContent = title;
-	entryElement.append(headline);
+	entry.append(headline);
 
 	const descriptionList = document.createElement('dl');
 	descriptionList.className = 'storage__credentials';

--- a/sessions/js-forms-2/demo-start/js/index.js
+++ b/sessions/js-forms-2/demo-start/js/index.js
@@ -5,8 +5,8 @@ const storage = document.querySelector('[data-js="storage"]');
 const passwordInput = document.querySelector('[data-js="password-input"]');
 
 function addStorageEntry(title, email, password) {
-	const entryElement = document.createElement('li');
-	entryElement.className = 'storage__entry';
+	const entry = document.createElement('li');
+	entry.className = 'storage__entry';
 
 	const headline = document.createElement('h3');
 	headline.className = 'storage__title';

--- a/sessions/js-forms-2/demo-start/js/index.js
+++ b/sessions/js-forms-2/demo-start/js/index.js
@@ -34,7 +34,7 @@ function addStorageEntry(title, email, password) {
 
 	entry.append(descriptionList);
 
-	storage.append(entryElement);
+	storage.append(entry);
 }
 
 function updatePasswordStrength(text) {

--- a/sessions/js-forms-2/demo-start/js/index.js
+++ b/sessions/js-forms-2/demo-start/js/index.js
@@ -32,7 +32,7 @@ function addStorageEntry(title, email, password) {
 	descriptionDetailsTwo.textContent = password;
 	descriptionList.append(descriptionDetailsTwo);
 
-	entryElement.append(descriptionList);
+	entry.append(descriptionList);
 
 	storage.append(entryElement);
 }


### PR DESCRIPTION
The challenges avoid `innerHTML` because of security reasons.

This is why the demo should avoid it, too.

rendered: https://github.com/neuefische/web-exercises/tree/refactor/js-forms-2/demo-innerHTML/sessions/js-forms-2

## Codesandboxes
- [Start](https://codesandbox.io/s/github/neuefische/web-exercises/tree/refactor/js-forms-2/demo-innerHTML/sessions/js-forms-2/demo-start?file=/js/index.js)
- [End](https://codesandbox.io/s/github/neuefische/web-exercises/tree/refactor/js-forms-2/demo-innerHTML/sessions/js-forms-2/demo-end?file=/js/index.js)

refers to neuefische/web-curriculum-new-format#116