### PR TITLE
fix(js-array-methods): refactor second test of map challenge

### DIFF
--- a/sessions/js-array-methods/map/index.js
+++ b/sessions/js-array-methods/map/index.js
@@ -26,7 +26,7 @@ const cards = [
 
 const lowerCaseAnswers = null; // ['as often as you like.', ...]
 
-const questionsAndAnswersTogether = null; // ['"How often can I use <header>?" - "As often as you like."', ...]
+const questionsAndAnswersTogether = null; // ["How often can I use <header>? - As often as you like.", ...]
 
 const questionAndAnswer = null; // [{ question: 'How often can I use <header>?', answer: 'As often as you like.'}, {...}]
 

--- a/sessions/js-array-methods/map/index.test.js
+++ b/sessions/js-array-methods/map/index.test.js
@@ -14,9 +14,9 @@ describe("Mapping Challenge", () => {
   });
   test("questionsAndAnswersTogether", () => {
     expect(questionsAndAnswersTogether).toEqual([
-      '"How often can I use <header>?" - "As often as you like."',
-      '"How often can I use <aside>?" - "As often as you like."',
-      '"On which types can I use destructuring assignment?" - "On Objects and Arrays"',
+      "How often can I use <header>? - As often as you like.",
+      "How often can I use <aside>? - As often as you like.",
+      "On which types can I use destructuring assignment? - On Objects and Arrays",
     ]);
   });
   test("questionAndAnswer", () => {


### PR DESCRIPTION
## Reasoning
- Students needed to much time figuring out the usage of single and double quotes to make the second test work.
- It's not necessary to use both kinds of quotes in this test in order to understand how the `map` method works.

## Changes
- change the expectation of `questionsAndAnswersTogether` to expect only one string containing the question and answer, separated by a dash `-`.

fixes neuefische/web-curriculum-new-format#247