### PR TITLE
Move accessibility demo to web-exercises

### DIFF
--- a/sessions/accessibility/demo-end/.gitignore
+++ b/sessions/accessibility/demo-end/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/sessions/accessibility/demo-end/.prettierrc.json
+++ b/sessions/accessibility/demo-end/.prettierrc.json
@@ -1,0 +1,22 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "jsxBracketSameLine": false,
+  "arrowParens": "always",
+  "requirePragma": false,
+  "insertPragma": false,
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "vueIndentScriptAndStyle": false,
+  "endOfLine": "lf",
+  "embeddedLanguageFormatting": "auto",
+  "singleAttributePerLine": false
+}

--- a/sessions/accessibility/demo-end/README.md
+++ b/sessions/accessibility/demo-end/README.md
@@ -1,0 +1,14 @@
+# Accessibility: Demo End
+
+This is the conclusion of the Accessibility demo.
+
+## Development
+
+### CodeSandbox
+
+Select the "Browser" tab to view this project.
+
+### Local development
+
+Use the Live Preview Extension for Visual Studio Code to view this project in the browser.  
+Select the HTML file you want to view, press <kbd>⇧</kbd><kbd>⌘</kbd><kbd>P</kbd>, search for `Live Preview: Show Preview` and confirm with <kbd>Enter</kbd>.

--- a/sessions/accessibility/demo-end/README.md
+++ b/sessions/accessibility/demo-end/README.md
@@ -1,6 +1,6 @@
 # Accessibility: Demo End
 
-This is the conclusion of the Accessibility demo.
+This is the conclusion of the accessibility demo.
 
 ## Development
 

--- a/sessions/accessibility/demo-end/index.html
+++ b/sessions/accessibility/demo-end/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Accessibility: Semantic Exercise</title>
+  </head>
+  <body>
+    <h1>My two favorite book series</h1>
+    <main>
+      <section>
+        <h2>The Expanse</h2>
+        <p>
+          A great since fiction series set in the not to far future. Humans have
+          colonized the solar system. The basic constellation is the conflict
+          and political tensions between earth, mars and the outer planets.
+        </p>
+        <h3>First three books:</h3>
+        <ul>
+          <li>Leviathan Wakes</li>
+          <li>Caliban's War</li>
+          <li>Abaddon's Gate</li>
+        </ul>
+      </section>
+      <section>
+        <h2>The Hunger Games</h2>
+        <p>
+          The Hunger Games is a series of young adult dystopian novels written
+          by the American author Suzanne Collins. The series is set in the
+          Hunger Games universe, with the first three novels being a trilogy
+          following teenage protagonist, Katniss Everdeen.
+        </p>
+        <h3>Three book titles:</h3>
+        <ul>
+          <li>The Hunger Games</li>
+          <li>Catching Fire</li>
+          <li>Mockingjay</li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/sessions/accessibility/demo-end/package.json
+++ b/sessions/accessibility/demo-end/package.json
@@ -1,7 +1,7 @@
 {
   "name": "accessibility_demo-end",
   "version": "0.0.0-unreleased",
-  "description": "accessibility: demo-end",
+  "description": "Accessibility: Demo End",
   "main": "index.html",
   "nf": {
     "template": "html-css-static"

--- a/sessions/accessibility/demo-end/package.json
+++ b/sessions/accessibility/demo-end/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "accessibility_demo-end",
+  "version": "0.0.0-unreleased",
+  "description": "accessibility: demo-end",
+  "main": "index.html",
+  "nf": {
+    "template": "html-css-static"
+  },
+  "private": true
+}

--- a/sessions/accessibility/demo-end/sandbox.config.json
+++ b/sessions/accessibility/demo-end/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/sessions/accessibility/demo-start/.gitignore
+++ b/sessions/accessibility/demo-start/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/sessions/accessibility/demo-start/.prettierrc.json
+++ b/sessions/accessibility/demo-start/.prettierrc.json
@@ -1,0 +1,22 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "jsxBracketSameLine": false,
+  "arrowParens": "always",
+  "requirePragma": false,
+  "insertPragma": false,
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "vueIndentScriptAndStyle": false,
+  "endOfLine": "lf",
+  "embeddedLanguageFormatting": "auto",
+  "singleAttributePerLine": false
+}

--- a/sessions/accessibility/demo-start/README.md
+++ b/sessions/accessibility/demo-start/README.md
@@ -1,0 +1,14 @@
+# Accessibility: Demo Start
+
+This is the starter for the Accessibility demo.
+
+## Development
+
+### CodeSandbox
+
+Select the "Browser" tab to view this project.
+
+### Local development
+
+Use the Live Preview Extension for Visual Studio Code to view this project in the browser.  
+Select the HTML file you want to view, press <kbd>⇧</kbd><kbd>⌘</kbd><kbd>P</kbd>, search for `Live Preview: Show Preview` and confirm with <kbd>Enter</kbd>.

--- a/sessions/accessibility/demo-start/index.html
+++ b/sessions/accessibility/demo-start/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Accessibility: Semantic Exercise</title>
+  </head>
+  <body>
+    <h1>Accessibility: Semantic Exercise</h1>
+    <div>My two favorite book series</div>
+    <div>
+      <div>
+        <div>The Expanse</div>
+        <div>
+          A great since fiction series set in the not to far future. Humans have
+          colonized the solar system. The basic constellation is the conflict
+          and political tensions between earth, mars and the outer planets.
+        </div>
+        <div>First three books:</div>
+        <div>- Leviathan Wakes</div>
+        <div>- Caliban's War</div>
+        <div>- Abaddon's Gate</div>
+      </div>
+      <div>
+        <div>The Hunger Games</div>
+        <div>
+          The Hunger Games is a series of young adult dystopian novels written
+          by the American author Suzanne Collins. The series is set in the
+          Hunger Games universe, with the first three novels being a trilogy
+          following teenage protagonist, Katniss Everdeen.
+        </div>
+        <div>Three book titles:</div>
+        <div>- The Hunger Games</div>
+        <div>- Catching Fire</div>
+        <div>- Mockingjay</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/sessions/accessibility/demo-start/index.html
+++ b/sessions/accessibility/demo-start/index.html
@@ -6,10 +6,9 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Accessibility: Semantic Exercise</title>
+    <title>Accessibility: Semantic Demo</title>
   </head>
   <body>
-    <h1>Accessibility: Semantic Exercise</h1>
     <div>My two favorite book series</div>
     <div>
       <div>

--- a/sessions/accessibility/demo-start/package.json
+++ b/sessions/accessibility/demo-start/package.json
@@ -1,7 +1,7 @@
 {
   "name": "accessibility_demo-start",
   "version": "0.0.0-unreleased",
-  "description": "accessibility: demo-start",
+  "description": "Accessibility: Demo Start",
   "main": "index.html",
   "nf": {
     "template": "html-css-static"

--- a/sessions/accessibility/demo-start/package.json
+++ b/sessions/accessibility/demo-start/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "accessibility_demo-start",
+  "version": "0.0.0-unreleased",
+  "description": "accessibility: demo-start",
+  "main": "index.html",
+  "nf": {
+    "template": "html-css-static"
+  },
+  "private": true
+}

--- a/sessions/accessibility/demo-start/sandbox.config.json
+++ b/sessions/accessibility/demo-start/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}


### PR DESCRIPTION
Use this demo on
[🔗 **CodeSandbox: Start**](https://codesandbox.io/s/github/neuefische/web-exercises/tree/accessibility_demo/sessions/accessibility/demo-start?file=/README.md)
[🔗 **CodeSandbox: End**](https://codesandbox.io/s/github/neuefische/web-exercises/tree/accessibility_demo/sessions/accessibility/demo-end?file=/README.md)
or locally by running this command in your Terminal:

```
npx ghcd@latest neuefische/web-exercises/tree/main/sessions/accessibility/demo-start -i
```
Note: 

- Fixes [#252 in NF Repo](https://github.com/neuefische/web-curriculum-new-format/issues/252)
- To-Do: Fix links in session guide