### PR TITLE
Add missing .env.local to root .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,8 @@ node_modules/
 *.tgz
 
 # dotenv environment variables file
-.env
-.env.local
-.env.test
+.env*
+!.env.local.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ node_modules/
 
 # dotenv environment variables file
 .env
+.env.local
 .env.test
 
 # parcel-bundler cache (https://parceljs.org/)


### PR DESCRIPTION
## Rationale
When I create a challenge which uses a MongoDB, I create a `.env.local` file in the corresponding project (let's say `/sessions/backend-create/products`.

While working in that branch locally, everything is fine because the project has its own `.gitignore` file.

Unfortunately, as soon as I switch to a branch where `/sessions/backend-create/products` does not yet exist (e.g. in `main`), there are some leftovers: a hidden `.next` folder, the `node_modules` folder and my recently created `.env.local`.

The problem: there is now no `.gitignore` file which is why `.env.local` is tracked by git.

See this screenshot:
<img width="245" alt="Screenshot 2023-01-06 at 14 51 51" src="https://user-images.githubusercontent.com/33567019/211025710-f2b96a15-8b16-4774-aa1a-11d4e215d98b.png">

## Solution
I add '.env.local' to the root `.gitignore`.

## Question
Is there a better way to handle this or can anything break by doing so?
