### PR TITLE
update swr dependency

### DIFF
--- a/sessions/react-data-fetching/iss-tracker/package.json
+++ b/sessions/react-data-fetching/iss-tracker/package.json
@@ -17,7 +17,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "styled-components": "^5.3.6",
-    "swr": "^1.3.0"
+    "swr": "^2.0.0"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",


### PR DESCRIPTION
If the students follow the current SWR docs example [here](https://swr.vercel.app/#overview), they will run into an error with SWR version < 2.0.0, since the current docs do not contain a check for `!data`, but instead only check for `error` and `isLoading`. You can only do this with SWR version >= 2.0.0 => hence the dependency update.