### PR TITLE
React Testing Library: update major version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1"
       }
@@ -4920,20 +4920,21 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.19.0",
-      "license": "MIT",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.1.tgz",
+      "integrity": "sha512-fTOVsMY9QLFCCXRHG3Ese6cMH5qIWwSbgxZsgeF5TNsy81HKaZ4kgehnSF8FsR3OF+numlIV2YcU79MzbnhSig==",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
+        "@types/aria-query": "^5.0.1",
         "aria-query": "^5.0.0",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
+        "lz-string": "^1.5.0",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@testing-library/dom/node_modules/aria-query": {
@@ -4982,15 +4983,16 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "13.4.0",
-      "license": "MIT",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+      "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.5.0",
+        "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": "^18.0.0",
@@ -5051,8 +5053,9 @@
       "peer": true
     },
     "node_modules/@types/aria-query": {
-      "version": "4.2.2",
-      "license": "MIT"
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -7846,6 +7849,10 @@
     },
     "node_modules/css-selectors_demo-start": {
       "resolved": "sessions/css-selectors/demo-start",
+      "link": true
+    },
+    "node_modules/css-structure_custom-properties": {
+      "resolved": "sessions/css-structure/custom-properties",
       "link": true
     },
     "node_modules/css-structure_selectors-and-cascading": {
@@ -13874,6 +13881,10 @@
       "resolved": "sessions/js-async-functions/relay-race",
       "link": true
     },
+    "node_modules/js-async-functions_sleep": {
+      "resolved": "sessions/js-async-functions/sleep",
+      "link": true
+    },
     "node_modules/js-async-functions_slot-machine": {
       "resolved": "sessions/js-async-functions/slot-machine",
       "link": true
@@ -14172,6 +14183,10 @@
     },
     "node_modules/js-structure_quiz-app": {
       "resolved": "sessions/js-structure/quiz-app",
+      "link": true
+    },
+    "node_modules/js-structure_shapes": {
+      "resolved": "sessions/js-structure/shapes",
       "link": true
     },
     "node_modules/js-structure_spacerocket": {
@@ -14550,8 +14565,9 @@
       }
     },
     "node_modules/lz-string": {
-      "version": "1.4.4",
-      "license": "WTFPL",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -21705,7 +21721,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -22043,7 +22059,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -22389,7 +22405,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -22728,7 +22744,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -23229,6 +23245,7 @@
       }
     },
     "sessions/backend-create/demo-end": {
+      "name": "backend-create_demo-end",
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@next/font": "^13.0.6",
@@ -23244,7 +23261,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -23587,6 +23604,7 @@
       }
     },
     "sessions/backend-create/demo-start": {
+      "name": "backend-create_demo-start",
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@next/font": "^13.0.6",
@@ -23602,7 +23620,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -23945,6 +23963,7 @@
       }
     },
     "sessions/backend-create/products": {
+      "name": "backend-create_products",
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@next/font": "^13.0.6",
@@ -23960,7 +23979,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -24327,7 +24346,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -24685,7 +24704,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -25024,7 +25043,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -25347,6 +25366,7 @@
       }
     },
     "sessions/backend-update-and-delete/products": {
+      "name": "backend-update-and-delete_products",
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@next/font": "^13.0.6",
@@ -25362,7 +25382,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -25757,9 +25777,11 @@
       "version": "0.0.0-unreleased"
     },
     "sessions/css-grid/demo-end": {
+      "name": "css-grid_demo-end",
       "version": "0.0.0-unreleased"
     },
     "sessions/css-grid/demo-start": {
+      "name": "css-grid_demo-start",
       "version": "0.0.0-unreleased"
     },
     "sessions/css-grid/fish-cards": {
@@ -25795,9 +25817,11 @@
       "version": "0.0.0-unreleased"
     },
     "sessions/css-positioning/demo-end": {
+      "name": "css-positioning_demo-end",
       "version": "0.0.0-unreleased"
     },
     "sessions/css-positioning/demo-start": {
+      "name": "css-positioning_demo-start",
       "version": "0.0.0-unreleased"
     },
     "sessions/css-positioning/layout-with-position": {
@@ -25836,6 +25860,9 @@
       "name": "css-selectors_demo-start",
       "version": "0.0.0-unreleased"
     },
+    "sessions/css-structure/custom-properties": {
+      "version": "0.0.0-unreleased"
+    },
     "sessions/css-structure/selectors-and-cascading": {
       "name": "css-structure_selectors-and-cascading",
       "version": "0.0.0-unreleased"
@@ -25845,6 +25872,7 @@
       "version": "0.0.0-unreleased"
     },
     "sessions/html-and-the-web/personal-website": {
+      "name": "html-and-the-web_personal-website",
       "version": "0.0.0-unreleased"
     },
     "sessions/html-forms/Finding-a11y-errors": {
@@ -26093,6 +26121,9 @@
       "name": "js-async-functions_relay-race",
       "version": "0.0.0-unreleased"
     },
+    "sessions/js-async-functions/sleep": {
+      "version": "0.0.0-unreleased"
+    },
     "sessions/js-async-functions/slot-machine": {
       "name": "js-async-functions_slot-machine",
       "version": "0.0.0-unreleased"
@@ -26106,9 +26137,11 @@
       "version": "0.0.0-unreleased"
     },
     "sessions/js-basics/demo-end": {
+      "name": "js-basics_demo-end",
       "version": "0.0.0-unreleased"
     },
     "sessions/js-basics/demo-start": {
+      "name": "js-basics_demo-start",
       "version": "0.0.0-unreleased"
     },
     "sessions/js-basics/survey-error-fixing": {
@@ -26777,6 +26810,9 @@
       "name": "js-structure_quiz-app",
       "version": "0.0.0-unreleased"
     },
+    "sessions/js-structure/shapes": {
+      "version": "0.0.0-unreleased"
+    },
     "sessions/js-structure/spacerocket": {
       "name": "js-structure_spacerocket",
       "version": "0.0.0-unreleased",
@@ -27008,7 +27044,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -27345,7 +27381,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -27682,7 +27718,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -28140,7 +28176,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -28478,7 +28514,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -28815,7 +28851,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -29153,7 +29189,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -29539,7 +29575,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -29876,7 +29912,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -30214,7 +30250,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -30552,7 +30588,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -31033,7 +31069,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -31370,7 +31406,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -31707,7 +31743,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -31729,7 +31765,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -32383,7 +32419,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -32723,7 +32759,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -33063,7 +33099,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -33402,7 +33438,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -33873,7 +33909,7 @@
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -33890,7 +33926,7 @@
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -34330,7 +34366,7 @@
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -34344,7 +34380,7 @@
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -34358,7 +34394,7 @@
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -34563,7 +34599,7 @@
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -34586,7 +34622,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -34923,7 +34959,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -35260,7 +35296,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -35597,7 +35633,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -35996,7 +36032,7 @@
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -36108,7 +36144,7 @@
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -36167,7 +36203,7 @@
       "version": "0.0.0-unreleased",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -36204,7 +36240,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint-plugin-jest": "^27.1.6",
         "jest": "^29.3.1",
@@ -39616,15 +39652,17 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.19.0",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.1.tgz",
+      "integrity": "sha512-fTOVsMY9QLFCCXRHG3Ese6cMH5qIWwSbgxZsgeF5TNsy81HKaZ4kgehnSF8FsR3OF+numlIV2YcU79MzbnhSig==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
+        "@types/aria-query": "^5.0.1",
         "aria-query": "^5.0.0",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
+        "lz-string": "^1.5.0",
         "pretty-format": "^27.0.2"
       },
       "dependencies": {
@@ -39666,10 +39704,12 @@
       }
     },
     "@testing-library/react": {
-      "version": "13.4.0",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+      "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.5.0",
+        "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
       }
     },
@@ -39707,7 +39747,9 @@
       "peer": true
     },
     "@types/aria-query": {
-      "version": "4.2.2"
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q=="
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -40685,7 +40727,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -40852,7 +40894,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -41023,7 +41065,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -41190,7 +41232,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "chance": "^1.1.9",
         "eslint": "8.29.0",
@@ -41459,7 +41501,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -41667,7 +41709,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -41875,7 +41917,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -42089,7 +42131,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -42297,7 +42339,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -42464,7 +42506,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -42632,7 +42674,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -43559,6 +43601,9 @@
     },
     "css-selectors_demo-start": {
       "version": "file:sessions/css-selectors/demo-start"
+    },
+    "css-structure_custom-properties": {
+      "version": "file:sessions/css-structure/custom-properties"
     },
     "css-structure_selectors-and-cascading": {
       "version": "file:sessions/css-structure/selectors-and-cascading"
@@ -47492,6 +47537,9 @@
     "js-async-functions_relay-race": {
       "version": "file:sessions/js-async-functions/relay-race"
     },
+    "js-async-functions_sleep": {
+      "version": "file:sessions/js-async-functions/sleep"
+    },
     "js-async-functions_slot-machine": {
       "version": "file:sessions/js-async-functions/slot-machine"
     },
@@ -47925,6 +47973,9 @@
     "js-structure_quiz-app": {
       "version": "file:sessions/js-structure/quiz-app"
     },
+    "js-structure_shapes": {
+      "version": "file:sessions/js-structure/shapes"
+    },
     "js-structure_spacerocket": {
       "version": "file:sessions/js-structure/spacerocket",
       "requires": {
@@ -48250,7 +48301,9 @@
       }
     },
     "lz-string": {
-      "version": "1.4.4"
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
     },
     "magic-string": {
       "version": "0.25.9",
@@ -48489,7 +48542,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -48655,7 +48708,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -48821,7 +48874,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -50096,7 +50149,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -50263,7 +50316,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -50430,7 +50483,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -50596,7 +50649,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -50801,7 +50854,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -50968,7 +51021,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -51134,7 +51187,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -51301,7 +51354,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -51637,7 +51690,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -51803,7 +51856,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -51969,7 +52022,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -52135,7 +52188,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -52301,7 +52354,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -52469,7 +52522,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -52638,7 +52691,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -52807,7 +52860,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -53090,7 +53143,7 @@
       "version": "file:sessions/react-project-setup/demo-project-structure",
       "requires": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -53106,7 +53159,7 @@
       "requires": {
         "@babel/runtime": "7.13.8",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -54225,7 +54278,7 @@
       "version": "file:sessions/react-state/journal-app-favorite-button",
       "requires": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -54449,7 +54502,7 @@
       "version": "file:sessions/react-state-3/journal-app-favorite-button-shared-state",
       "requires": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -54462,7 +54515,7 @@
       "version": "file:sessions/react-state-3/journal-app-filter",
       "requires": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -54475,7 +54528,7 @@
       "version": "file:sessions/react-state-3/journal-app-form",
       "requires": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -54508,7 +54561,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -54674,7 +54727,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -54840,7 +54893,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -55006,7 +55059,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
@@ -55227,7 +55280,7 @@
       "version": "file:sessions/react-with-arrays/journal-app-entries-array",
       "requires": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -55318,7 +55371,7 @@
       "version": "file:sessions/react-with-local-storage/journal-app-with-local-storage",
       "requires": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -55386,7 +55439,7 @@
       "version": "file:sessions/recap-project-4/example-implementation",
       "requires": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -55408,7 +55461,7 @@
         "@next/font": "^13.0.6",
         "@svgr/webpack": "^6.5.1",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1"
   }

--- a/sessions/backend-api-routes/demo-end/package.json
+++ b/sessions/backend-api-routes/demo-end/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-api-routes/demo-start/package.json
+++ b/sessions/backend-api-routes/demo-start/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-api-routes/products/package.json
+++ b/sessions/backend-api-routes/products/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-api-routes/random-character/package.json
+++ b/sessions/backend-api-routes/random-character/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-create/demo-end/package.json
+++ b/sessions/backend-create/demo-end/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-create/demo-start/package.json
+++ b/sessions/backend-create/demo-start/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-create/products/package.json
+++ b/sessions/backend-create/products/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-read/demo-end/package.json
+++ b/sessions/backend-read/demo-end/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-read/demo-start/package.json
+++ b/sessions/backend-read/demo-start/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-read/products/package.json
+++ b/sessions/backend-read/products/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/backend-update-and-delete/products/package.json
+++ b/sessions/backend-update-and-delete/products/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/nextjs-dynamic-routes/demo-end/package.json
+++ b/sessions/nextjs-dynamic-routes/demo-end/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "@testing-library/user-event": "^14.4.3",

--- a/sessions/nextjs-dynamic-routes/demo-start/package.json
+++ b/sessions/nextjs-dynamic-routes/demo-start/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "@testing-library/user-event": "^14.4.3",

--- a/sessions/nextjs-dynamic-routes/lotr-app-dynamic-routes/package.json
+++ b/sessions/nextjs-dynamic-routes/lotr-app-dynamic-routes/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "@testing-library/user-event": "^14.4.3",

--- a/sessions/react-component-testing/demo-end/package.json
+++ b/sessions/react-component-testing/demo-end/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",

--- a/sessions/react-component-testing/demo-start/package.json
+++ b/sessions/react-component-testing/demo-start/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",

--- a/sessions/react-component-testing/lotr-app-testing/package.json
+++ b/sessions/react-component-testing/lotr-app-testing/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "@testing-library/user-event": "^14.4.3",

--- a/sessions/react-component-testing/scorekeeper/package.json
+++ b/sessions/react-component-testing/scorekeeper/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",

--- a/sessions/react-data-fetching/demo-end/package.json
+++ b/sessions/react-data-fetching/demo-end/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-data-fetching/demo-start/package.json
+++ b/sessions/react-data-fetching/demo-start/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-data-fetching/iss-tracker/package.json
+++ b/sessions/react-data-fetching/iss-tracker/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-data-fetching/star-wars/package.json
+++ b/sessions/react-data-fetching/star-wars/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-global-state/demo-end/package.json
+++ b/sessions/react-global-state/demo-end/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-global-state/demo-start/package.json
+++ b/sessions/react-global-state/demo-start/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-global-state/lights-solution/package.json
+++ b/sessions/react-global-state/lights-solution/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-global-state/lights/package.json
+++ b/sessions/react-global-state/lights/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-immutable-state/car-race/package.json
+++ b/sessions/react-immutable-state/car-race/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-immutable-state/demo-end/package.json
+++ b/sessions/react-immutable-state/demo-end/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-immutable-state/demo-start/package.json
+++ b/sessions/react-immutable-state/demo-start/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-immutable-state/form/package.json
+++ b/sessions/react-immutable-state/form/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/sessions/react-project-setup/demo-project-structure/package.json
+++ b/sessions/react-project-setup/demo-project-structure/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/sessions/react-props/box-with-props/package.json
+++ b/sessions/react-props/box-with-props/package.json
@@ -8,7 +8,7 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "web-vitals": "^2.1.4"
   },

--- a/sessions/react-state-3/journal-app-favorite-button-shared-state/package.json
+++ b/sessions/react-state-3/journal-app-favorite-button-shared-state/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "uid": "^2.0.1",
     "react": "^18.2.0",

--- a/sessions/react-state-3/journal-app-filter/package.json
+++ b/sessions/react-state-3/journal-app-filter/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "uid": "^2.0.1",
     "react": "^18.2.0",

--- a/sessions/react-state-3/journal-app-form/package.json
+++ b/sessions/react-state-3/journal-app-form/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/sessions/react-state/journal-app-favorite-button/package.json
+++ b/sessions/react-state/journal-app-favorite-button/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/sessions/react-styled-components/box/package.json
+++ b/sessions/react-styled-components/box/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "@testing-library/user-event": "^14.4.3",

--- a/sessions/react-styled-components/demo-end/package.json
+++ b/sessions/react-styled-components/demo-end/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "@testing-library/user-event": "^14.4.3",

--- a/sessions/react-styled-components/demo-start/package.json
+++ b/sessions/react-styled-components/demo-start/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "@testing-library/user-event": "^14.4.3",

--- a/sessions/react-styled-components/lotr-app-styling/package.json
+++ b/sessions/react-styled-components/lotr-app-styling/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "@testing-library/user-event": "^14.4.3",

--- a/sessions/react-with-arrays/journal-app-entries-array/package.json
+++ b/sessions/react-with-arrays/journal-app-entries-array/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/sessions/react-with-local-storage/journal-app-with-local-storage/package.json
+++ b/sessions/react-with-local-storage/journal-app-with-local-storage/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "uid": "^2.0.1",
     "react": "^18.2.0",

--- a/sessions/recap-project-4/example-implementation/package.json
+++ b/sessions/recap-project-4/example-implementation/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "uid": "^2.0.1",
     "react": "^18.2.0",

--- a/sessions/recap-project-5/example-implementation/package.json
+++ b/sessions/recap-project-5/example-implementation/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/templates/cra/package.json
+++ b/templates/cra/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",


### PR DESCRIPTION
## Rationale
- The `v13` of @testing-library/react throws a false error regarding the `act()` function when using the `userEvent` within tests.

- `v14` [fixes this issue](https://github.com/testing-library/react-testing-library/releases/tag/v14.0.0).
- Read [our discussion in Slack here](https://neuefische-students.slack.com/archives/C03M7V42UJJ/p1678707358362249).

- I checked `v14.0.0` in react-component-testing_demo-start before applying these changes to the entire repository.

## Changes
- update all @testing-library/react instances in package.json files
- run `npm install` to update root `package-lock.json`