### PR TITLE
fix: make sure the active class is toggled on the button 

### DIFF
--- a/sessions/js-structure/quiz-app/index.js
+++ b/sessions/js-structure/quiz-app/index.js
@@ -168,7 +168,7 @@ function Card(props) {
     cards.find((card) => card.question === props.question).isBookmarked =
       !props.isBookmarked;
     // To prevent the need to rerender, we can just toggle the class here
-    event.target.classList.toggle("bookmark--active");
+    event.currentTarget.classList.toggle("bookmark--active");
   }
 
   const bookmarkButton = Bookmark({


### PR DESCRIPTION
The active class must be toggled on the button element(event.currentTarget)
instead of the svg or path element (current.target) (which could have been the trigger for the event)

https://user-images.githubusercontent.com/4458383/226622565-86cf4649-71fe-439e-a754-b762cdb53635.mov

