### PR TITLE
fix: remove function declarations

### DIFF
--- a/sessions/js-functions/pizza-analyzer/README.md
+++ b/sessions/js-functions/pizza-analyzer/README.md
@@ -18,7 +18,7 @@ First, we want to calculate the difference of the two pizza areas for two given 
    > 💡 You can use the queried elements and get their value like this: `pizzaInput.value`
 6. Now call the function and pass in the two pizza sizes as the arguments.
 
-### 2 Change pizza dipslay sizes
+### 2 Change the Pizza Display Sizes
 
 Great! Now we know how much pizza we gain if we choose the second pizza. But we don't have any visual relations between these two numbers. So lets adapt the pizza displays.
 

--- a/sessions/js-functions/pizza-analyzer/js/index.js
+++ b/sessions/js-functions/pizza-analyzer/js/index.js
@@ -17,19 +17,10 @@ pizzaInput2.addEventListener("input", () => {
 });
 
 // Task 1
-
-function calculatePizzaGain(diameter1, diameter2) {
-  // write your code here
-}
+// define the function calculatePizzaGain here
 
 // Task 2
-
-function updatePizzaDisplay(pizzaElement, newSize) {
-  // write your code here
-}
+// define the function updatePizzaDisplay here
 
 // Task 3
-
-function updateOutputColor(size1, size2) {
-  // write your code here
-}
+// define the function updateOutputColor here


### PR DESCRIPTION
Since the students should practice writing function declarations and the spiced students got confused with the task descriptions, I removed the declarations from the starter code.