### PR TITLE
Update space rocket challenge

### DIFF
--- a/sessions/js-structure/spacerocket/jest.config.js
+++ b/sessions/js-structure/spacerocket/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: "jsdom",
+};

--- a/sessions/js-structure/spacerocket/js/core/rocket.js
+++ b/sessions/js-structure/spacerocket/js/core/rocket.js
@@ -17,9 +17,9 @@ export function getNewRocket() {
 }
 
 export function getRocket() {
-  if (!global.rocket) {
+  if (!window.rocket) {
     throw new Error("No rocket found");
   }
 
-  return global.rocket;
+  return window.rocket;
 }

--- a/sessions/js-structure/spacerocket/js/launchSequence.test.js
+++ b/sessions/js-structure/spacerocket/js/launchSequence.test.js
@@ -5,11 +5,11 @@ import * as launchSequence from "./launchSequence.js";
 const launchSequenceFunction = launchSequence?.default;
 
 beforeEach(() => {
-  global.rocket = getNewRocket();
+  window.rocket = getNewRocket();
 });
 
 afterEach(() => {
-  delete global.rocket;
+  delete window.rocket;
 });
 
 test("The default export of launchSequence.js is a function", () => {

--- a/sessions/js-structure/spacerocket/package.json
+++ b/sessions/js-structure/spacerocket/package.json
@@ -13,7 +13,8 @@
     "@types/jest": "^29.2.0",
     "eslint-plugin-jest": "^27.1.3",
     "eslint": "^8.26.0",
-    "jest": "^29.2.2"
+    "jest": "^29.2.2",
+    "jest-environment-jsdom": "^29.5.0"
   },
   "nf": {
     "template": "html-css-js"


### PR DESCRIPTION
**Problem:** Locally the task could not be solved because `global` was used. If the sequence was started when pressing Start, there was an error message: "global is not defined".

Together with @shebtastic we rebuilt the Space Rocket Challenge so that it would now work locally if the challenge was solved correctly and also the tests will pass.

This solution should not close [this issue](https://github.com/neuefische/web-curriculum/issues/315), but can be a solution until this issue is finally discussed.

I tested everything before creating the PR, but feel free to try it remotely and locally to see if it works for you. As a solution for the `launchSequence.js` to see if the rocket starts without error message, you can copy this one in:

```js
// Implement the launch sequence function here and export it as the default export.
import { loadPayload } from "./core/load.js";
import { NFSAT, FISHSAT } from "./payload/satellites.js";
import { fuel } from "./core/fuel.js";
import { countdown } from "./core/countdown.js";
import { liftoff } from "./core/liftoff.js";
import { deployPayload } from "./core/deploy.js";
// Implement the launch sequence function here and export it as the default export.

export default function launch() {
  loadPayload(NFSAT);
  loadPayload(FISHSAT);
  fuel();
  countdown(5);
  countdown(4);
  countdown(3);
  countdown(2);
  countdown(1);
  liftoff();
  deployPayload();
}
```
