### PR TITLE
React Nesting Navigation Challenge: update readme

### DIFF
--- a/sessions/react-nesting/navigation/README.md
+++ b/sessions/react-nesting/navigation/README.md
@@ -72,11 +72,11 @@ You should now have an `App` component returning only your custom components (be
 To check, you App.js file should look something like this now:
 
 ```js
-import { Avatar } from "./components/Avatar";
-import { Header } from "./components/Header";
-import { Link } from "./components/Link";
-import { Logo } from "./components/Logo";
-import { Navigation } from "./components/Navigation";
+import Header from "./components/Header";
+import Avatar from "./components/Avatar";
+import Logo from "./components/Logo";
+import Navigation from "./components/Navigation";
+import Link from "./components/Link";
 import "./styles.css";
 
 export default function App() {


### PR DESCRIPTION
**Observation:** Our students have noticed that the readme file uses named import statements for components in our example `App.js`. Even though this is possible, it is different from what we show in our session and what we do afterwards. Examples:
- In our [composition demo](https://codesandbox.io/s/github/neuefische/web-exercises/tree/main/sessions/react-nesting/demo-composition?file=/src/App.js) we use default exports for components
- our example solution for this challenge uses default exports for components 
- in our following sessions we use default export for components (see for example [Demo for React Project Setup](https://codesandbox.io/s/github/neuefische/web-exercises/tree/main/sessions/react-project-setup/demo-project-structure), [Demo for React with Arrays](https://codesandbox.io/s/github/neuefische/web-exercises/tree/main/sessions/react-with-arrays/demo-end?file=/src/App.js) or [Journal App Challenge for React State 3](https://codesandbox.io/s/github/neuefische/web-exercises/tree/main/sessions/react-state-3/journal-app-filter?file=/src/components/Badge/index.js))
 
It is unclear to me why students should work with named exports for this challenge and that is why I suggest using default imports and to update the readme file.