### PR TITLE
change next-version to 13.2.4 in React-Styled-Components

### DIFF
--- a/sessions/react-styled-components/box/package.json
+++ b/sessions/react-styled-components/box/package.json
@@ -12,11 +12,10 @@
   "dependencies": {
     "eslint": "8.29.0",
     "eslint-config-next": "13.0.6",
-    "next": "13.0.6",
+    "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "styled-components": "^5.3.6",
-    "@next/font": "^13.0.6"
+    "styled-components": "^5.3.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/sessions/react-styled-components/demo-end/package.json
+++ b/sessions/react-styled-components/demo-end/package.json
@@ -10,10 +10,9 @@
     "test": "jest --watchAll"
   },
   "dependencies": {
-    "@next/font": "^13.0.6",
     "eslint": "8.29.0",
     "eslint-config-next": "13.0.6",
-    "next": "13.0.6",
+    "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "styled-components": "^5.3.6"

--- a/sessions/react-styled-components/demo-start/package.json
+++ b/sessions/react-styled-components/demo-start/package.json
@@ -10,10 +10,9 @@
     "test": "jest --watchAll"
   },
   "dependencies": {
-    "@next/font": "^13.0.6",
     "eslint": "8.29.0",
     "eslint-config-next": "13.0.6",
-    "next": "13.0.6",
+    "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "styled-components": "^5.3.6"

--- a/sessions/react-styled-components/lotr-app-styling/package.json
+++ b/sessions/react-styled-components/lotr-app-styling/package.json
@@ -12,11 +12,10 @@
   "dependencies": {
     "eslint": "8.29.0",
     "eslint-config-next": "13.0.6",
-    "next": "13.0.6",
+    "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "styled-components": "^5.3.6",
-    "@next/font": "^13.0.6"
+    "styled-components": "^5.3.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
To better use next.js font optimization I changed the next-version in the package.json to 13.2.4 in the session "React-Styled-Components"