### PR TITLE
delete @ from next/font/google-path

### DIFF
--- a/sessions/react-styled-components/demo-end/styles.js
+++ b/sessions/react-styled-components/demo-end/styles.js
@@ -1,5 +1,5 @@
 import { createGlobalStyle } from "styled-components";
-import { Open_Sans } from "@next/font/google";
+import { Open_Sans } from "next/font/google";
 
 const openSans = Open_Sans({ subsets: ["latin"] });
 


### PR DESCRIPTION
after updating next from 13.0.6 to 13.2.4 the character '@' is deprecated in:
import { Open_Sans } from "@next/font/google";