### PR TITLE
Minor Change: Update CSS Selectors Demo

### DIFF
--- a/sessions/css-selectors/demo-end/css/styles.css
+++ b/sessions/css-selectors/demo-end/css/styles.css
@@ -64,12 +64,12 @@ a[href^="https"] {
 /* PART 4: I'm a pseudo-class. I'm  a keyword added to a selector that 
 specifies a special state of the selected element. */
 
-a[href^="https"]:hover {
+a:hover {
   background-color: #ff69b4;
   color: #fff;
 }
 
-input[type="text"]:focus {
+input:focus {
   outline: 2px solid #ff69b4;
   border: none;
   border-radius: 3px;
@@ -89,7 +89,7 @@ a[href^="https"]:before {
 
 /* PART 6: I'm the ID selector. I shouldn't be used. */
 
-#very-important-text {
+#do-not-use-this {
   color: #fff;
 }
 

--- a/sessions/css-selectors/demo-end/css/styles.css
+++ b/sessions/css-selectors/demo-end/css/styles.css
@@ -1,10 +1,6 @@
 /* I'm the universal selector. I target EVERYTHING. */
-*,
-*::before,
-*::after {
+* {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
 }
 
 /* PART 1: I'm a type selector. I target a specific type of element. */
@@ -115,11 +111,4 @@ of the parent element, but only those children that match my type. */
   padding: 20px;
   background-color: #ffb6c1;
   border: 4px dotted #fff;
-}
-
-/* PART 9: I'm an adjacent sibling selector. The rules I declare 
-only count for my adjacent sibling. */
-
-section div + span {
-  color: #ff69b4;
 }

--- a/sessions/css-selectors/demo-end/index.html
+++ b/sessions/css-selectors/demo-end/index.html
@@ -60,7 +60,7 @@
             eggs, and milk, and made tastier with chocolate, fruit, or whipped
             cream.
           </p>
-          <p class="text" id="very-important-text">Cake is delicious!</p>
+          <p class="text" id="do-not-use-this">Cake is delicious!</p>
           <p class="text">There is a lot to say about cakes.</p>
         </article>
       </section>

--- a/sessions/css-selectors/demo-start/css/styles.css
+++ b/sessions/css-selectors/demo-start/css/styles.css
@@ -49,10 +49,10 @@ a[href^="https"] {
 /* PART 4: I'm a pseudo-class. I'm  a keyword added to a selector that 
 specifies a special state of the selected element. */
 
-a[href^="https"]:hover {
+a:hover {
 }
 
-input[type="text"]:focus {
+input:focus {
 }
 
 /* PART 5: I'm a pseudo-element. I'm a keyword added to a selector that lets
@@ -66,7 +66,7 @@ a[href^="https"]:before {
 
 /* PART 6: I'm the ID selector. I shouldn't be used. */
 
-#very-important-text {
+#do-not-use-this {
 }
 
 /* PART 7: I'm a descendant combinator. I will select all descendants

--- a/sessions/css-selectors/demo-start/css/styles.css
+++ b/sessions/css-selectors/demo-start/css/styles.css
@@ -1,10 +1,6 @@
 /* I'm the universal selector. I target EVERYTHING. */
-*,
-*::before,
-*::after {
+* {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
 }
 
 /* PART 1: I'm a type selector. I target a specific type of element. */
@@ -87,10 +83,4 @@ of the parent element, but only those descendants that match my type. */
 of the parent element, but only those children that match my type. */
 
 .main-section > article {
-}
-
-/* PART 9: I'm an adjacent sibling selector. The rules I declare 
-only count for my adjacent sibling. */
-
-section div + span {
 }

--- a/sessions/css-selectors/demo-start/index.html
+++ b/sessions/css-selectors/demo-start/index.html
@@ -60,7 +60,7 @@
             eggs, and milk, and made tastier with chocolate, fruit, or whipped
             cream.
           </p>
-          <p class="text" id="very-important-text">Cake is delicious!</p>
+          <p class="text" id="do-not-use-this">Cake is delicious!</p>
           <p class="text">There is a lot to say about cakes.</p>
         </article>
       </section>


### PR DESCRIPTION
- as part of the update of the CSS Selectors guide I want to propose two small changes for the CSS Selectors Demo:
  - remove *::before and *::after: pseudo elements will be explained later during the session, but these stylings are there from the start. This could be confusing and I think it is not necessary for this session that we work with ::before and ::after from the beginning
  - I would not remove default margins and paddings with the universal selector as it may be better to have some space between the examples from the beginning
  - and I would propose to remove the last combinator example of the demo. Two examples should be enough (as the session is already long enough) and they can learn more about combinators with the handout
