### PR TITLE
Fix: create-react-app related warning concerning babel dependency

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -13,13 +13,13 @@ They can also be used to create new **projects outside of this repository** usin
 
 ## Why?
 
-Basic templates only contain files. But we want to do more advanced things for Create React App and Next.js: Those templates are created using `create-react-app` and `create-next-app` and then we modify them to our needs by adding and modifiying files as well as running additional commands.
+Basic templates only contain files. But we want to do more advanced things for Create React App and Next.js: Those templates are created using `create-react-app` and `create-next-app` and then we modify them to our needs by adding and modifying files as well as running additional commands.
 
 ## How?
 
 For each recipe, we have a `files` directory that contains the files that should be copied to the template.
 
-There is a `exercise-overrides` directory that contains files that should be overriden by the `create` script, when the template is used to create a new exercise. This allows us to have a different `README.md` (and other files) for exercises.
+There is an `exercise-overrides` directory that contains files that should be overridden by the `create` script, when the template is used to create a new exercise. This allows us to have a different `README.md` (and other files) for exercises.
 
 Each recipe has a `recipe.js` file that exports a default object. This object contains the following properties:
 

--- a/recipes/react-minimal/files/package.json
+++ b/recipes/react-minimal/files/package.json
@@ -9,6 +9,7 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
+    "@babel/runtime": "7.22.11",
     "eslint-plugin-react-hooks": "4.6.0",
     "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },

--- a/recipes/react-minimal/files/package.json
+++ b/recipes/react-minimal/files/package.json
@@ -9,8 +9,8 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/html-and-the-web-new/div-salad/package.json
+++ b/sessions/html-and-the-web-new/div-salad/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "html-and-the-web_div-salad",
+  "name": "html-and-the-web_div-salad-new",
   "version": "0.0.0-unreleased",
   "description": "Static HTML template with CSS",
   "main": "index.html",

--- a/sessions/html-and-the-web-new/personal-website/package.json
+++ b/sessions/html-and-the-web-new/personal-website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "html-and-the-web_personal-website",
+  "name": "html-and-the-web_personal-website-new",
   "version": "0.0.0-unreleased",
   "description": "HTML and the web: Personal Website",
   "main": "n.a.",

--- a/sessions/react-basics/attributes/.eslintrc.json
+++ b/sessions/react-basics/attributes/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-basics/attributes/package.json
+++ b/sessions/react-basics/attributes/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-basics/demo-inner-html-vs-render/.eslintrc.json
+++ b/sessions/react-basics/demo-inner-html-vs-render/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-basics/demo-inner-html-vs-render/package.json
+++ b/sessions/react-basics/demo-inner-html-vs-render/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-basics/demo-render/.eslintrc.json
+++ b/sessions/react-basics/demo-render/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-basics/demo-render/package.json
+++ b/sessions/react-basics/demo-render/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-basics/hello-world-article/.eslintrc.json
+++ b/sessions/react-basics/hello-world-article/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-basics/hello-world-article/package.json
+++ b/sessions/react-basics/hello-world-article/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-basics/hello-world/.eslintrc.json
+++ b/sessions/react-basics/hello-world/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-basics/hello-world/package.json
+++ b/sessions/react-basics/hello-world/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-custom-hooks/demo-end/.eslintrc.json
+++ b/sessions/react-custom-hooks/demo-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-custom-hooks/demo-end/package.json
+++ b/sessions/react-custom-hooks/demo-end/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-custom-hooks/demo-start/.eslintrc.json
+++ b/sessions/react-custom-hooks/demo-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-custom-hooks/demo-start/package.json
+++ b/sessions/react-custom-hooks/demo-start/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-effects-and-fetch/api-status/.eslintrc.json
+++ b/sessions/react-effects-and-fetch/api-status/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-effects-and-fetch/api-status/package.json
+++ b/sessions/react-effects-and-fetch/api-status/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-effects-and-fetch/demo-end/.eslintrc.json
+++ b/sessions/react-effects-and-fetch/demo-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-effects-and-fetch/demo-end/package.json
+++ b/sessions/react-effects-and-fetch/demo-end/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-effects-and-fetch/demo-start/.eslintrc.json
+++ b/sessions/react-effects-and-fetch/demo-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-effects-and-fetch/demo-start/package.json
+++ b/sessions/react-effects-and-fetch/demo-start/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-effects-and-fetch/iss-tracker/.eslintrc.json
+++ b/sessions/react-effects-and-fetch/iss-tracker/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-effects-and-fetch/iss-tracker/package.json
+++ b/sessions/react-effects-and-fetch/iss-tracker/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-effects-and-fetch/pokemon-api-with-paging/.eslintrc.json
+++ b/sessions/react-effects-and-fetch/pokemon-api-with-paging/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-effects-and-fetch/pokemon-api-with-paging/package.json
+++ b/sessions/react-effects-and-fetch/pokemon-api-with-paging/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-effects-and-fetch/pokemon-api/.eslintrc.json
+++ b/sessions/react-effects-and-fetch/pokemon-api/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-effects-and-fetch/pokemon-api/package.json
+++ b/sessions/react-effects-and-fetch/pokemon-api/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-nesting/buttons-and-children/.eslintrc.json
+++ b/sessions/react-nesting/buttons-and-children/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-nesting/buttons-and-children/package.json
+++ b/sessions/react-nesting/buttons-and-children/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-nesting/demo-composition/.eslintrc.json
+++ b/sessions/react-nesting/demo-composition/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-nesting/demo-composition/package.json
+++ b/sessions/react-nesting/demo-composition/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-nesting/demo-end/.eslintrc.json
+++ b/sessions/react-nesting/demo-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-nesting/demo-end/package.json
+++ b/sessions/react-nesting/demo-end/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-nesting/demo-start/.eslintrc.json
+++ b/sessions/react-nesting/demo-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-nesting/demo-start/package.json
+++ b/sessions/react-nesting/demo-start/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-nesting/fragments/.eslintrc.json
+++ b/sessions/react-nesting/fragments/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-nesting/fragments/package.json
+++ b/sessions/react-nesting/fragments/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-nesting/navigation/.eslintrc.json
+++ b/sessions/react-nesting/navigation/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-nesting/navigation/package.json
+++ b/sessions/react-nesting/navigation/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-props/button/.eslintrc.json
+++ b/sessions/react-props/button/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-props/button/package.json
+++ b/sessions/react-props/button/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-props/demo-end/.eslintrc.json
+++ b/sessions/react-props/demo-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-props/demo-end/package.json
+++ b/sessions/react-props/demo-end/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-props/demo-start/.eslintrc.json
+++ b/sessions/react-props/demo-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-props/demo-start/package.json
+++ b/sessions/react-props/demo-start/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-props/greeting/.eslintrc.json
+++ b/sessions/react-props/greeting/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-props/greeting/package.json
+++ b/sessions/react-props/greeting/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-props/smiley/.eslintrc.json
+++ b/sessions/react-props/smiley/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-props/smiley/package.json
+++ b/sessions/react-props/smiley/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-props/sum/.eslintrc.json
+++ b/sessions/react-props/sum/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-props/sum/package.json
+++ b/sessions/react-props/sum/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-2/colored-number/.eslintrc.json
+++ b/sessions/react-state-2/colored-number/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-2/colored-number/package.json
+++ b/sessions/react-state-2/colored-number/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-2/conditional-usestate/.eslintrc.json
+++ b/sessions/react-state-2/conditional-usestate/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-2/conditional-usestate/package.json
+++ b/sessions/react-state-2/conditional-usestate/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-2/demo-end/.eslintrc.json
+++ b/sessions/react-state-2/demo-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-2/demo-end/package.json
+++ b/sessions/react-state-2/demo-end/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-2/demo-start/.eslintrc.json
+++ b/sessions/react-state-2/demo-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-2/demo-start/package.json
+++ b/sessions/react-state-2/demo-start/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-2/favourite-holiday/.eslintrc.json
+++ b/sessions/react-state-2/favourite-holiday/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-2/favourite-holiday/package.json
+++ b/sessions/react-state-2/favourite-holiday/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-2/personal-details/.eslintrc.json
+++ b/sessions/react-state-2/personal-details/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-2/personal-details/package.json
+++ b/sessions/react-state-2/personal-details/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-2/table-reservation/.eslintrc.json
+++ b/sessions/react-state-2/table-reservation/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-2/table-reservation/package.json
+++ b/sessions/react-state-2/table-reservation/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-2/triple-count/.eslintrc.json
+++ b/sessions/react-state-2/triple-count/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-2/triple-count/package.json
+++ b/sessions/react-state-2/triple-count/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-3/adding-animals/.eslintrc.json
+++ b/sessions/react-state-3/adding-animals/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-3/adding-animals/package.json
+++ b/sessions/react-state-3/adding-animals/package.json
@@ -10,8 +10,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-3/demo-end/.eslintrc.json
+++ b/sessions/react-state-3/demo-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-3/demo-end/package.json
+++ b/sessions/react-state-3/demo-end/package.json
@@ -10,8 +10,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-3/demo-start/.eslintrc.json
+++ b/sessions/react-state-3/demo-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-3/demo-start/package.json
+++ b/sessions/react-state-3/demo-start/package.json
@@ -10,8 +10,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state-3/tags/.eslintrc.json
+++ b/sessions/react-state-3/tags/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state-3/tags/package.json
+++ b/sessions/react-state-3/tags/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state/box/.eslintrc.json
+++ b/sessions/react-state/box/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state/box/package.json
+++ b/sessions/react-state/box/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state/counter/.eslintrc.json
+++ b/sessions/react-state/counter/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state/counter/package.json
+++ b/sessions/react-state/counter/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state/demo-counter-end/.eslintrc.json
+++ b/sessions/react-state/demo-counter-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state/demo-counter-end/package.json
+++ b/sessions/react-state/demo-counter-end/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state/demo-counter-start/.eslintrc.json
+++ b/sessions/react-state/demo-counter-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state/demo-counter-start/package.json
+++ b/sessions/react-state/demo-counter-start/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state/demo-food-order-end/.eslintrc.json
+++ b/sessions/react-state/demo-food-order-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state/demo-food-order-end/package.json
+++ b/sessions/react-state/demo-food-order-end/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state/demo-food-order-start/.eslintrc.json
+++ b/sessions/react-state/demo-food-order-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state/demo-food-order-start/package.json
+++ b/sessions/react-state/demo-food-order-start/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-state/emoji-checker/.eslintrc.json
+++ b/sessions/react-state/emoji-checker/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-state/emoji-checker/package.json
+++ b/sessions/react-state/emoji-checker/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-with-arrays/demo-end/.eslintrc.json
+++ b/sessions/react-with-arrays/demo-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-with-arrays/demo-end/package.json
+++ b/sessions/react-with-arrays/demo-end/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-with-arrays/demo-start/.eslintrc.json
+++ b/sessions/react-with-arrays/demo-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-with-arrays/demo-start/package.json
+++ b/sessions/react-with-arrays/demo-start/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-with-arrays/fruits/.eslintrc.json
+++ b/sessions/react-with-arrays/fruits/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-with-arrays/fruits/package.json
+++ b/sessions/react-with-arrays/fruits/package.json
@@ -24,8 +24,9 @@
     ]
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "nf": {
     "template": "react-minimal"

--- a/sessions/react-with-arrays/users/.eslintrc.json
+++ b/sessions/react-with-arrays/users/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-with-arrays/users/package.json
+++ b/sessions/react-with-arrays/users/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-with-local-storage/demo-end/.eslintrc.json
+++ b/sessions/react-with-local-storage/demo-end/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-with-local-storage/demo-end/package.json
+++ b/sessions/react-with-local-storage/demo-end/package.json
@@ -11,8 +11,9 @@
     "use-local-storage-state": "^18.1.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-with-local-storage/demo-start/.eslintrc.json
+++ b/sessions/react-with-local-storage/demo-start/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-with-local-storage/demo-start/package.json
+++ b/sessions/react-with-local-storage/demo-start/package.json
@@ -10,8 +10,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-with-local-storage/dice/.eslintrc.json
+++ b/sessions/react-with-local-storage/dice/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-with-local-storage/dice/package.json
+++ b/sessions/react-with-local-storage/dice/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/sessions/react-with-local-storage/stored-note/.eslintrc.json
+++ b/sessions/react-with-local-storage/stored-note/.eslintrc.json
@@ -17,7 +17,10 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "react"],
+  "plugins": [
+    "jest",
+    "react"
+  ],
   "rules": {
     "react/prop-types": 0,
     "react/react-in-jsx-scope": 0,

--- a/sessions/react-with-local-storage/stored-note/package.json
+++ b/sessions/react-with-local-storage/stored-note/package.json
@@ -10,8 +10,9 @@
     "use-local-storage-state": "^18.1.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/templates/react-minimal/package.json
+++ b/templates/react-minimal/package.json
@@ -9,8 +9,9 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.20.0",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "@babel/runtime": "7.22.11",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   },
   "scripts": {
     "start": "react-scripts start"


### PR DESCRIPTION
This PR fixes the warning shown in React app which had been create using CRA.

![Screenshot 2023-08-23 at 11 54 15](https://github.com/neuefische/web-exercises/assets/4458383/305c410d-b885-452c-b809-34af2f3a14f3)
