### PR TITLE
fix: add download commands for next basics challenge

### DIFF
--- a/sessions/nextjs-basics-and-routing/lotr-app/.codesandbox/tasks.json
+++ b/sessions/nextjs-basics-and-routing/lotr-app/.codesandbox/tasks.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://codesandbox.io/schemas/tasks.json",
-  "setupTasks": ["npm i"]
-}

--- a/sessions/nextjs-basics-and-routing/lotr-app/.gitignore
+++ b/sessions/nextjs-basics-and-routing/lotr-app/.gitignore
@@ -1,2 +1,0 @@
-node_modules
-.DS_Store

--- a/sessions/nextjs-basics-and-routing/lotr-app/README.md
+++ b/sessions/nextjs-basics-and-routing/lotr-app/README.md
@@ -72,7 +72,15 @@ Use a width of `140px` and a height of `230px` for the cover image.
 
 ## Resources
 
-You can find the movie data, introduction and images in [this folder](./resources/).
+You can find the movie data, introduction and images in [this folder](./resources/). You can download them with our `ghcd` tool by using these commands inside your project folder:
+
+```bash
+npx ghcd@latest neuefische/web-exercises/tree/main/sessions/nextjs-basics-and-routing/lotr-app/resources resources
+```
+
+```bash
+npx ghcd@latest neuefische/web-exercises/tree/main/sessions/nextjs-basics-and-routing/lotr-app/design-resources design-resources
+```
 
 - The files are already in the correct structure for the app.
   - `lib/data.js` contains the data for the app.

--- a/sessions/nextjs-basics-and-routing/lotr-app/package.json
+++ b/sessions/nextjs-basics-and-routing/lotr-app/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "nextjs-basics-and-routing_lotr-app",
-  "version": "0.0.0-unreleased",
-  "description": "Next.js Basics: Lord of the Rings App",
-  "main": "n.a.",
-  "nf": {
-    "template": "empty"
-  }
-}

--- a/sessions/nextjs-basics-and-routing/lotr-app/sandbox.config.json
+++ b/sessions/nextjs-basics-and-routing/lotr-app/sandbox.config.json
@@ -1,1 +1,0 @@
-{ "template": "static" }


### PR DESCRIPTION
- add ghcd commands for downloading the resources, since the students use a template project instead of the linked repository with the instructions.
- remove package.json, .gitignore and codesandbox config files