### PR TITLE
fix: rename classic package.json names

### DIFF
--- a/sessions/js-fetch-classic/color-clue/package.json
+++ b/sessions/js-fetch-classic/color-clue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-fetch_color-clue",
+  "name": "js-fetch_color-clue-classic",
   "version": "0.0.0-unreleased",
   "description": "Color Clue Challenge for JS Fetch Session",
   "main": "index.html",

--- a/sessions/js-fetch-classic/demo-end/package.json
+++ b/sessions/js-fetch-classic/demo-end/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-fetch_demo-end",
+  "name": "js-fetch_demo-end-classic",
   "version": "0.0.0-unreleased",
   "description": "Start of Demo for JS Fetch",
   "main": "index.html",

--- a/sessions/js-fetch-classic/demo-start/package.json
+++ b/sessions/js-fetch-classic/demo-start/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-fetch_demo-start",
+  "name": "js-fetch_demo-start-classic",
   "version": "0.0.0-unreleased",
   "description": "End of Demo for JS Fetch",
   "main": "index.html",

--- a/sessions/js-fetch-classic/star-wars-console/package.json
+++ b/sessions/js-fetch-classic/star-wars-console/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-fetch_star-wars-console",
+  "name": "js-fetch_star-wars-console-classic",
   "version": "0.0.0-unreleased",
   "description": "Fetch Star Wars API and log data to console",
   "main": "index.html",

--- a/sessions/js-fetch-classic/star-wars/package.json
+++ b/sessions/js-fetch-classic/star-wars/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-fetch_star-wars",
+  "name": "js-fetch_star-wars-classic",
   "version": "0.0.0-unreleased",
   "description": "Fetch Star Wars API and display Cards",
   "main": "index.html",


### PR DESCRIPTION
When running any npm command in the web-exercises repo, duplicate package names throw an error.

This PR removes the duplicates from the `js-fetch-classic` folder