### PR TITLE
Fix minor inconsistency with naming styled components

### DIFF
--- a/sessions/react-styled-components-1/styled-navbar/README.md
+++ b/sessions/react-styled-components-1/styled-navbar/README.md
@@ -9,10 +9,6 @@ Switch to the `./pages/_app.js` file and make something great happen!
 - Style the `Link` so that there is no underline. Hint: Check the handout for an example of how to do this. Additional hint: we can set [the following](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) to `none`.
 - Style the `Link` so that the `Link` gets underlined on hover.
 
-## Notes
-
-- You only have to touch the `./pages/index.js` file.
-
 ## Development
 
 ### Local Development

--- a/sessions/react-styled-components-1/styled-navbar/pages/_app.js
+++ b/sessions/react-styled-components-1/styled-navbar/pages/_app.js
@@ -2,7 +2,7 @@ import Link from "next/link";
 import GlobalStyle from "../styles";
 import styled from "styled-components";
 
-const Nav = styled.nav`
+const StyledNav = styled.nav`
   border-bottom: solid 2px grey;
   padding: 1rem;
 `;
@@ -17,7 +17,7 @@ export default function App({ Component, pageProps }) {
   return (
     <>
       <GlobalStyle />
-      <Nav>
+      <StyledNav>
         <StyledList>
           <li>
             <Link href="/">Home</Link>
@@ -29,7 +29,7 @@ export default function App({ Component, pageProps }) {
             <Link href="/contact">Contact</Link>
           </li>
         </StyledList>
-      </Nav>
+      </StyledNav>
       <Component {...pageProps} />
     </>
   );


### PR DESCRIPTION
This PR resolves two minor issues:
- The README tells students they would only have to touch the `index.js` whereas they will have to work in the `_app.js`
- All styled components should be prefixed with `Styled` as per our convention.