### PR TITLE
Bad wording was leading students towards error.

### DIFF
--- a/sessions/backend-read/products/README.md
+++ b/sessions/backend-read/products/README.md
@@ -37,8 +37,8 @@ The schema should have the following fields:
 
 At the root of the project, create a `.env.local` file which uses the `MONGODB_URI` environment variable and your MongoDB connection string.
 
-- Copy and paste the following into the `.env.local` file: `MONGODB_URI=mongodb+srv://<user>:<password>@<cluster-name>/fish-shop?retryWrites=true&w=majority`.
-- Replace `<user>` with your database username, `<password>` with your password and `<cluster-name>` with the name of your cluster. You can find all of this information on the MongoDB Atlas website.
+- Copy and paste the following into the `.env.local` file: `MONGODB_URI=mongodb+srv://<user>:<password>@<cluster-url>/fish-shop?retryWrites=true&w=majority`.
+- Replace `<user>` with your database username, `<password>` with your password and `<cluster-url>` with the URL of your cluster. You can find all of this information on the MongoDB Atlas website.
 
 Switch to `pages/api/products/index.js`:
 


### PR DESCRIPTION
Students would enter only the cluster name, as per description and then would get an error "URI must include hostname, domain name, and tld". By calling it cluster URL we can avoid such missunderstanding.