### PR TITLE
replace .js with .jsx endings in Readmes of vite projects

### DIFF
--- a/sessions/react-basics/attributes/README.md
+++ b/sessions/react-basics/attributes/README.md
@@ -4,7 +4,7 @@ By now, you are familiar with rendering HTML in React and how to extract this HT
 
 Let's now focus on HTML attributes in JSX and the (minor) differences to normal HTML.
 
-Have a look at the [App.js](./src/App.js) file: you will find the `App` returning a single `<div>`.
+Have a look at the [App.jsx](./src/App.jsx) file: you will find the `App` returning a single `<div>`.
 
 ## Task
 
@@ -20,7 +20,7 @@ Your component should contain the following parts:
 ## Notes
 
 - You rendered Article component does not have any styling? Remember that you need to use `className` instead of `class` in JSX.
-- You only have to touch the [App.js](src/App.js) file.
+- You only have to touch the [App.jsx](src/App.jsx) file.
 
 ## Development
 

--- a/sessions/react-basics/attributes_solution/README.md
+++ b/sessions/react-basics/attributes_solution/README.md
@@ -4,7 +4,7 @@ By now, you are familiar with rendering HTML in React and how to extract this HT
 
 Let's now focus on HTML attributes in JSX and the (minor) differences to normal HTML.
 
-Have a look at the [App.js](./src/App.js) file: you will find the `App` returning a single `<div>`.
+Have a look at the [App.jsx](./src/App.jsx) file: you will find the `App` returning a single `<div>`.
 
 ## Task
 
@@ -20,7 +20,7 @@ Your component should contain the following parts:
 ## Notes
 
 - You rendered Article component does not have any styling? Remember that you need to use `className` instead of `class` in JSX.
-- You only have to touch the [App.js](src/App.js) file.
+- You only have to touch the [App.jsx](src/App.jsx) file.
 
 ## Development
 

--- a/sessions/react-basics/demo-end/README.md
+++ b/sessions/react-basics/demo-end/README.md
@@ -2,7 +2,7 @@
 
 ## Notes
 
-- Open the `./src/index.js` file to present this demo.
+- Open the `./src/index.jsx` file to present this demo.
 
 ## Development
 

--- a/sessions/react-basics/demo-render/README.md
+++ b/sessions/react-basics/demo-render/README.md
@@ -2,7 +2,7 @@
 
 ## Notes
 
-- Open the `./src/index.js` file to present this demo.
+- Open the `./src/index.jsx` file to present this demo.
 
 ## Development
 

--- a/sessions/react-basics/demo-start/README.md
+++ b/sessions/react-basics/demo-start/README.md
@@ -2,7 +2,7 @@
 
 ## Notes
 
-- Open the `./src/index.js` file to present this demo.
+- Open the `./src/index.jsx` file to present this demo.
 
 ## Development
 

--- a/sessions/react-basics/hello-world-article/README.md
+++ b/sessions/react-basics/hello-world-article/README.md
@@ -2,7 +2,7 @@
 
 Welcome back to the React Universe! This exercise lets you build a React component containing more than one HTML tag.
 
-Have a look at the [App.js](./src/App.js) file: the default export function called `App` returns a `<div>` which wants to be replaced. Let us comply with its request!
+Have a look at the [App.jsx](./src/App.jsx) file: the default export function called `App` returns a `<div>` which wants to be replaced. Let us comply with its request!
 
 ## Task
 
@@ -10,7 +10,7 @@ Render an HTML `article` tag containing a heading and a paragraph to the browser
 
 Use the following hints as guideline:
 
-- In the [App.js](src/App.js), create a new function called `HelloWorldArticle()`.
+- In the [App.jsx](src/App.jsx), create a new function called `HelloWorldArticle()`.
 - `HelloWorldArticle()` should return an HTML `article` tag as a wrapper which contains;
   - an `h1` heading
   - at least one `p` tag
@@ -20,7 +20,7 @@ Use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the [App.js](src/App.js) file.
+- You only have to touch the [App.jsx](src/App.jsx) file.
 
 ## Development
 

--- a/sessions/react-basics/hello-world-article_solution/README.md
+++ b/sessions/react-basics/hello-world-article_solution/README.md
@@ -2,7 +2,7 @@
 
 Welcome back to the React Universe! This exercise lets you build a React component containing more than one HTML tag.
 
-Have a look at the [App.js](./src/App.js) file: the default export function called `App` returns a `<div>` which wants to be replaced. Let us comply with its request!
+Have a look at the [App.jsx](./src/App.jsx) file: the default export function called `App` returns a `<div>` which wants to be replaced. Let us comply with its request!
 
 ## Task
 
@@ -10,7 +10,7 @@ Render an HTML `article` tag containing a heading and a paragraph to the browser
 
 Use the following hints as guideline:
 
-- In the [App.js](src/App.js), create a new function called `HelloWorldArticle()`.
+- In the [App.jsx](src/App.jsx), create a new function called `HelloWorldArticle()`.
 - `HelloWorldArticle()` should return an HTML `article` tag as a wrapper which contains;
   - an `h1` heading
   - at least one `p` tag
@@ -20,7 +20,7 @@ Use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the [App.js](src/App.js) file.
+- You only have to touch the [App.jsx](src/App.jsx) file.
 
 ## Development
 

--- a/sessions/react-basics/hello-world/README.md
+++ b/sessions/react-basics/hello-world/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the React Universe!
 
-Have a look at the [App.jsx](./src/App.jsx) file: you will find a default export function called `App` which returns a `<div>`.
+Have a look at the [App.jsxx](./src/App.jsxx) file: you will find a default export function called `App` which returns a `<div>`.
 
 Start you application and open it in your browser: the content of the `<div>` ("Say hello...") should be visible there as well.
 
@@ -24,14 +24,14 @@ To do so, create a component (i.e. function) called `HelloWorld`.
 
 Use the following hints as guideline:
 
-- In the [App.js](src/App.js), create a new function called `HelloWorld()` (it does not matter whether you write it above or below the `App` function - but not inside it!).
+- In the [App.jsx](src/App.jsx), create a new function called `HelloWorld()` (it does not matter whether you write it above or below the `App` function - but not inside it!).
 - `HelloWorld()` should return the same HTML heading as in the first task above.
 - In the return statement of the `App` function, replace the `h1` with your `HelloWorld` component.
 - Look at the browser and be amazed: nothing has changed, but you've built and used your first React component!
 
 ## Notes
 
-- You only have to touch the [App.js](src/App.js) file.
+- You only have to touch the [App.jsx](src/App.jsx) file.
 
 ## Development
 

--- a/sessions/react-basics/hello-world/README.md
+++ b/sessions/react-basics/hello-world/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the React Universe!
 
-Have a look at the [App.jsxx](./src/App.jsxx) file: you will find a default export function called `App` which returns a `<div>`.
+Have a look at the [App.jsx](./src/App.jsx) file: you will find a default export function called `App` which returns a `<div>`.
 
 Start you application and open it in your browser: the content of the `<div>` ("Say hello...") should be visible there as well.
 

--- a/sessions/react-basics/hello-world_solution/README.md
+++ b/sessions/react-basics/hello-world_solution/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the React Universe!
 
-Have a look at the [App.js](./src/App.js) file: you will find a default export function called `App` which returns a `<div>`.
+Have a look at the [App.jsx](./src/App.jsx) file: you will find a default export function called `App` which returns a `<div>`.
 
 Start you application and open it in your browser: the content of the `<div>` ("Say hello...") should be visible there as well.
 
@@ -24,14 +24,14 @@ To do so, create a component (i.e. function) called `HelloWorld`.
 
 Use the following hints as guideline:
 
-- In the [App.js](src/App.js), create a new function called `HelloWorld()` (it does not matter whether you write it above or below the `App` function - but not inside it!).
+- In the [App.jsx](src/App.jsx), create a new function called `HelloWorld()` (it does not matter whether you write it above or below the `App` function - but not inside it!).
 - `HelloWorld()` should return the same HTML heading as in the first task above.
 - In the return statement of the `App` function, replace the `h1` with your `HelloWorld` component.
 - Look at the browser and be amazed: nothing has changed, but you've built and used your first React component!
 
 ## Notes
 
-- You only have to touch the [App.js](src/App.js) file.
+- You only have to touch the [App.jsx](src/App.jsx) file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/api-status/README.md
+++ b/sessions/react-effects-and-fetch/api-status/README.md
@@ -4,7 +4,7 @@ This App offers an interface to check the status of an API.
 
 ## Task
 
-Look at the `./src/components/StatusCheck/index.js` file.
+Look at the `./src/components/StatusCheck/index.jsx` file.
 
 There is a function named `handleCheckApiStatus`. The function is called when you click the button.
 
@@ -36,7 +36,7 @@ Do you have an idea how to catch this kind of error? Can you implement the error
 
 ## Notes
 
-- You only have to touch the `./src/components/StatusCheck/index.js` file.
+- You only have to touch the `./src/components/StatusCheck/index.jsx` file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/api-status_solution/README.md
+++ b/sessions/react-effects-and-fetch/api-status_solution/README.md
@@ -4,7 +4,7 @@ This App offers an interface to check the status of an API.
 
 ## Task
 
-Look at the `./src/components/StatusCheck/index.js` file.
+Look at the `./src/components/StatusCheck/index.jsx` file.
 
 There is a function named `handleCheckApiStatus`. The function is called when you click the button.
 
@@ -36,7 +36,7 @@ Do you have an idea how to catch this kind of error? Can you implement the error
 
 ## Notes
 
-- You only have to touch the `./src/components/StatusCheck/index.js` file.
+- You only have to touch the `./src/components/StatusCheck/index.jsx` file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/demo-end/README.md
+++ b/sessions/react-effects-and-fetch/demo-end/README.md
@@ -3,7 +3,7 @@
 ## Notes
 
 - This is the final version of the demo.
-- You only have to touch the `./src/components/Jokes.js` file.
+- You only have to touch the `./src/components/Jokes.jsx` file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/demo-start/README.md
+++ b/sessions/react-effects-and-fetch/demo-start/README.md
@@ -3,7 +3,7 @@
 ## Notes
 
 - This is the start version of the demo.
-- You only have to touch the `./src/components/Jokes.js` file.
+- You only have to touch the `./src/components/Jokes.jsx` file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/iss-tracker/README.md
+++ b/sessions/react-effects-and-fetch/iss-tracker/README.md
@@ -4,7 +4,7 @@ In this challenge we will build a small app which displays the current location 
 
 ## Task
 
-In the `./src/App.js` file, we already have a state called `coords` in the `App` component which will hold the longitude and latitude values of the ISS position.
+In the `./src/App.jsx` file, we already have a state called `coords` in the `App` component which will hold the longitude and latitude values of the ISS position.
 
 1. Write the function `getISSCoords`. Fetch from the given url saved in the constant `URL`. After fetching successfully update the `coords` state accordingly.
 
@@ -17,11 +17,11 @@ In the `./src/App.js` file, we already have a state called `coords` in the `App`
 
 > 💡 Returning a cleanup function is important to not set multiple timers simultaneously. If you wouldn't define a cleanup function, each initial render of the component would start another timer that would never be stopped. This results in updating the coordinates way more often than desired.
 
-Go into the `./src/App.js` file and start coding!
+Go into the `./src/App.jsx` file and start coding!
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/iss-tracker_solution/README.md
+++ b/sessions/react-effects-and-fetch/iss-tracker_solution/README.md
@@ -4,7 +4,7 @@ In this challenge we will build a small app which displays the current location 
 
 ## Task
 
-In the `./src/App.js` file, we already have a state called `coords` in the `App` component which will hold the longitude and latitude values of the ISS position.
+In the `./src/App.jsx` file, we already have a state called `coords` in the `App` component which will hold the longitude and latitude values of the ISS position.
 
 1. Write the function `getISSCoords`. Fetch from the given url saved in the constant `URL`. After fetching successfully update the `coords` state accordingly.
 
@@ -17,11 +17,11 @@ In the `./src/App.js` file, we already have a state called `coords` in the `App`
 
 > 💡 Returning a cleanup function is important to not set multiple timers simultaneously. If you wouldn't define a cleanup function, each initial render of the component would start another timer that would never be stopped. This results in updating the coordinates way more often than desired.
 
-Go into the `./src/App.js` file and start coding!
+Go into the `./src/App.jsx` file and start coding!
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/pokemon-api-with-paging/README.md
+++ b/sessions/react-effects-and-fetch/pokemon-api-with-paging/README.md
@@ -6,7 +6,7 @@ We want to display a list of all Pokémon, but the API returns only `20` Pokémo
 
 ### The "Next Page" button
 
-Open the file `./src/components/PokemonList.js`.
+Open the file `./src/components/PokemonList.jsx`.
 
 There is a button to show the next page, but it has no functionality yet. Try to find a way to load the next page.
 
@@ -24,7 +24,7 @@ You might experience that the app crashes when you are on the first page and cli
 
 ## Notes
 
-- You only have to touch the `./src/components/PokemonList.js` file.
+- You only have to touch the `./src/components/PokemonList.jsx` file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/pokemon-api-with-paging_solution/README.md
+++ b/sessions/react-effects-and-fetch/pokemon-api-with-paging_solution/README.md
@@ -6,7 +6,7 @@ We want to display a list of all Pokémon, but the API returns only `20` Pokémo
 
 ### The "Next Page" button
 
-Open the file `./src/components/PokemonList.js`.
+Open the file `./src/components/PokemonList.jsx`.
 
 There is a button to show the next page, but it has no functionality yet. Try to find a way to load the next page.
 
@@ -24,7 +24,7 @@ You might experience that the app crashes when you are on the first page and cli
 
 ## Notes
 
-- You only have to touch the `./src/components/PokemonList.js` file.
+- You only have to touch the `./src/components/PokemonList.jsx` file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/pokemon-api/README.md
+++ b/sessions/react-effects-and-fetch/pokemon-api/README.md
@@ -4,7 +4,7 @@ This app should load and display a list of Pokémon.
 
 ## Task
 
-Open the file `./src/components/PokemonList.js`.
+Open the file `./src/components/PokemonList.jsx`.
 
 For now the Pokémon are only fetched when we click the button below. Let's change the code so that our app does this automatically when the app renders.
 
@@ -15,7 +15,7 @@ _Hint:_ Don't forget the dependency array!
 
 ## Notes
 
-- You only have to touch the `./src/components/PokemonList.js` file.
+- You only have to touch the `./src/components/PokemonList.jsx` file.
 
 ## Development
 

--- a/sessions/react-effects-and-fetch/pokemon-api_solution/README.md
+++ b/sessions/react-effects-and-fetch/pokemon-api_solution/README.md
@@ -4,7 +4,7 @@ This app should load and display a list of Pokémon.
 
 ## Task
 
-Open the file `./src/components/PokemonList.js`.
+Open the file `./src/components/PokemonList.jsx`.
 
 For now the Pokémon are only fetched when we click the button below. Let's change the code so that our app does this automatically when the app renders.
 
@@ -15,7 +15,7 @@ _Hint:_ Don't forget the dependency array!
 
 ## Notes
 
-- You only have to touch the `./src/components/PokemonList.js` file.
+- You only have to touch the `./src/components/PokemonList.jsx` file.
 
 ## Development
 

--- a/sessions/react-nesting/buttons-and-children/README.md
+++ b/sessions/react-nesting/buttons-and-children/README.md
@@ -1,6 +1,6 @@
 # React Nesting: Buttons and Children
 
-For now, there is a `Button` component in the `./src/App.js` which is rendered several times.
+For now, there is a `Button` component in the `./src/App.jsx` which is rendered several times.
 
 Unfortunately, all buttons show the same text; supposing that different buttons do different things in an application, this is not really a reuseable component.
 
@@ -8,7 +8,7 @@ Let's use the `children` prop to make the component more flexible!
 
 ## Task
 
-Switch to the `./src/App.js` file and
+Switch to the `./src/App.jsx` file and
 
 1. in the `Button` component, receive the `children` prop as parameter; make sure to destructure it.
 2. replace the "Click me!" text with the `children` prop (don't forget the curly braces `{}`).
@@ -19,7 +19,7 @@ Switch to the `./src/App.js` file and
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-nesting/buttons-and-children_solution/README.md
+++ b/sessions/react-nesting/buttons-and-children_solution/README.md
@@ -1,6 +1,6 @@
 # React Nesting: Buttons and Children
 
-For now, there is a `Button` component in the `./src/App.js` which is rendered several times.
+For now, there is a `Button` component in the `./src/App.jsx` which is rendered several times.
 
 Unfortunately, all buttons show the same text; supposing that different buttons do different things in an application, this is not really a reuseable component.
 
@@ -8,7 +8,7 @@ Let's use the `children` prop to make the component more flexible!
 
 ## Task
 
-Switch to the `./src/App.js` file and
+Switch to the `./src/App.jsx` file and
 
 1. in the `Button` component, receive the `children` prop as parameter; make sure to destructure it.
 2. replace the "Click me!" text with the `children` prop (don't forget the curly braces `{}`).
@@ -19,7 +19,7 @@ Switch to the `./src/App.js` file and
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-nesting/demo-start/README.md
+++ b/sessions/react-nesting/demo-start/README.md
@@ -2,7 +2,7 @@
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 - You find the end point for this demo in `sessions/react-nesting/demo-end`.
 
 ## Development

--- a/sessions/react-nesting/fragments/README.md
+++ b/sessions/react-nesting/fragments/README.md
@@ -6,13 +6,13 @@ Let's dive into it and see how React fragments can help here!
 
 ## Task
 
-Look at the `./src/App.js` file: there is a `<main>` element containing three `Box` components with different colors.
+Look at the `./src/App.jsx` file: there is a `<main>` element containing three `Box` components with different colors.
 
 Note that the `<main>` wrapper is a flex container which is why the `Box` components are aligned horizontically.
 
 Task: Outsource the three `Box` components to a `Boxes` component.
 
-- In the `App.js` file, create a `Boxes` component which
+- In the `App.jsx` file, create a `Boxes` component which
   - returns the same three `Box` components as given above.
   - For now, use a `<div>` component as a wrapper in the return statement of the `Boxes` component.
 - In the `App` component, replace the three `Box` components with the `Boxes` component.
@@ -31,7 +31,7 @@ To fix this, replace the `<div>` with fragments `<></>`: they won't create an HT
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-nesting/fragments_solution/README.md
+++ b/sessions/react-nesting/fragments_solution/README.md
@@ -6,13 +6,13 @@ Let's dive into it and see how React fragments can help here!
 
 ## Task
 
-Look at the `./src/App.js` file: there is a `<main>` element containing three `Box` components with different colors.
+Look at the `./src/App.jsx` file: there is a `<main>` element containing three `Box` components with different colors.
 
 Note that the `<main>` wrapper is a flex container which is why the `Box` components are aligned horizontically.
 
 Task: Outsource the three `Box` components to a `Boxes` component.
 
-- In the `App.js` file, create a `Boxes` component which
+- In the `App.jsx` file, create a `Boxes` component which
   - returns the same three `Box` components as given above.
   - For now, use a `<div>` component as a wrapper in the return statement of the `Boxes` component.
 - In the `App` component, replace the three `Box` components with the `Boxes` component.
@@ -31,7 +31,7 @@ To fix this, replace the `<div>` with fragments `<></>`: they won't create an HT
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-nesting/navigation/README.md
+++ b/sessions/react-nesting/navigation/README.md
@@ -1,6 +1,6 @@
 # React Nesting: Navigation
 
-For now, there is a navigation in the `./src/App.js` file which only uses built-in React components.
+For now, there is a navigation in the `./src/App.jsx` file which only uses built-in React components.
 
 Let's refactor to use custom components instead; you will encounter the `children` prop and recap props in general.
 
@@ -13,11 +13,11 @@ In order to provide a clear guide, the exercise is split into sub-tasks to help 
 Task: Outsource the `<header>` into a `Header` component.
 
 - In the `/src` folder, create a subfolder called `components`. This is where all component files will live.
-- In `/src/components`, create a file called `Header.js`.
-  - Export a `Header` component which returns the same `<header></header>` element as in the `App.js` file.
+- In `/src/components`, create a file called `Header.jsx`.
+  - Export a `Header` component which returns the same `<header></header>` element as in the `App.jsx` file.
   - Don't forget the `className` attribute.
   - The function should receive a `children` prop and render it between the opening and closing `<header>` tags.
-- In the `App.js` file, import the `Header` component and replace the `<header></header>` tags with it.
+- In the `App.jsx` file, import the `Header` component and replace the `<header></header>` tags with it.
 
 🎉 Congratulations, you've created a wrapping `Header` component using the `children` prop!
 
@@ -27,10 +27,10 @@ Let's do (almost) the same with the navigation.
 
 Task: Outsource the `<nav>` into a `Navigation` component.
 
-- Create `src/components/Navigation.js`.
+- Create `src/components/Navigation.jsx`.
 - The `Navigation` should receive a `children` prop used in its return statement.
   - 💡 Note that the `nav` does not have a `className`, so there is no need to add this attribute.
-- In the `App.js` file, import the `Navigation` component and replace the `<nav></nav>` tags with it.
+- In the `App.jsx` file, import the `Navigation` component and replace the `<nav></nav>` tags with it.
 
 Awesome! You are a true `children` prop professional now. Let's dive deeper!
 
@@ -42,7 +42,7 @@ Task: Create a `Link` component to render `<a>` tags.
 - The `Link` component returns an `<a>` element with `className="navigation__link"` and receives the props
   - `href` which is passed to the `href` attribute of the `<a>` tag and
   - `children` passed between the opening and closing `<a>` tags.
-- In the `App.js` file, import the `Link` component and replace the `<a></a>` tags with it.
+- In the `App.jsx` file, import the `Link` component and replace the `<a></a>` tags with it.
   - Make sure to pass the correct prop(s?).
 
 🎉 Awesome, you've created a very flexible `Link` component! Want more? You'll get more!
@@ -61,17 +61,17 @@ Task: Create an `Image` component to render `<img>` tags.
 
 Task: Create a `Logo` and `Avatar` component, respectively.
 
-- Use the same JSX as in the `App.js` as basis (copy the tags including `<a>` or `<button>` tag and their children)
+- Use the same JSX as in the `App.jsx` as basis (copy the tags including `<a>` or `<button>` tag and their children)
   - import the `Image` component and use it.
   - make sure to import the correct `jpg` file.
-- In the `App.js` file, import the `Logo` and `Avatar` component and replace the relevant JSX to use them.
+- In the `App.jsx` file, import the `Logo` and `Avatar` component and replace the relevant JSX to use them.
 - Check that the UI still looks the same.
 
 You should now have an `App` component returning only your custom components (besides `main`)! Nice work 🎉
 
-To check, you App.js file should look something like this now:
+To check, you App.jsx file should look something like this now:
 
-```js
+``.jsx
 import Header from "./components/Header";
 import Avatar from "./components/Avatar";
 import Logo from "./components/Logo";
@@ -99,7 +99,7 @@ export default function App() {
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file and the files you are going to create during this exercise.
+- You only have to touch the `./src/App.jsx` file and the files you are going to create during this exercise.
 
 ## Development
 

--- a/sessions/react-nesting/navigation_solution/README.md
+++ b/sessions/react-nesting/navigation_solution/README.md
@@ -1,6 +1,6 @@
 # React Nesting: Navigation
 
-For now, there is a navigation in the `./src/App.js` file which only uses built-in React components.
+For now, there is a navigation in the `./src/App.jsx` file which only uses built-in React components.
 
 Let's refactor to use custom components instead; you will encounter the `children` prop and recap props in general.
 
@@ -13,11 +13,11 @@ In order to provide a clear guide, the exercise is split into sub-tasks to help 
 Task: Outsource the `<header>` into a `Header` component.
 
 - In the `/src` folder, create a subfolder called `components`. This is where all component files will live.
-- In `/src/components`, create a file called `Header.js`.
-  - Export a `Header` component which returns the same `<header></header>` element as in the `App.js` file.
+- In `/src/components`, create a file called `Header.jsx`.
+  - Export a `Header` component which returns the same `<header></header>` element as in the `App.jsx` file.
   - Don't forget the `className` attribute.
   - The function should receive a `children` prop and render it between the opening and closing `<header>` tags.
-- In the `App.js` file, import the `Header` component and replace the `<header></header>` tags with it.
+- In the `App.jsx` file, import the `Header` component and replace the `<header></header>` tags with it.
 
 🎉 Congratulations, you've created a wrapping `Header` component using the `children` prop!
 
@@ -27,10 +27,10 @@ Let's do (almost) the same with the navigation.
 
 Task: Outsource the `<nav>` into a `Navigation` component.
 
-- Create `src/components/Navigation.js`.
+- Create `src/components/Navigation.jsx`.
 - The `Navigation` should receive a `children` prop used in its return statement.
   - 💡 Note that the `nav` does not have a `className`, so there is no need to add this attribute.
-- In the `App.js` file, import the `Navigation` component and replace the `<nav></nav>` tags with it.
+- In the `App.jsx` file, import the `Navigation` component and replace the `<nav></nav>` tags with it.
 
 Awesome! You are a true `children` prop professional now. Let's dive deeper!
 
@@ -42,7 +42,7 @@ Task: Create a `Link` component to render `<a>` tags.
 - The `Link` component returns an `<a>` element with `className="navigation__link"` and receives the props
   - `href` which is passed to the `href` attribute of the `<a>` tag and
   - `children` passed between the opening and closing `<a>` tags.
-- In the `App.js` file, import the `Link` component and replace the `<a></a>` tags with it.
+- In the `App.jsx` file, import the `Link` component and replace the `<a></a>` tags with it.
   - Make sure to pass the correct prop(s?).
 
 🎉 Awesome, you've created a very flexible `Link` component! Want more? You'll get more!
@@ -61,17 +61,17 @@ Task: Create an `Image` component to render `<img>` tags.
 
 Task: Create a `Logo` and `Avatar` component, respectively.
 
-- Use the same JSX as in the `App.js` as basis (copy the tags including `<a>` or `<button>` tag and their children)
+- Use the same JSX as in the `App.jsx` as basis (copy the tags including `<a>` or `<button>` tag and their children)
   - import the `Image` component and use it.
   - make sure to import the correct `jpg` file.
-- In the `App.js` file, import the `Logo` and `Avatar` component and replace the relevant JSX to use them.
+- In the `App.jsx` file, import the `Logo` and `Avatar` component and replace the relevant JSX to use them.
 - Check that the UI still looks the same.
 
 You should now have an `App` component returning only your custom components (besides `main`)! Nice work 🎉
 
-To check, you App.js file should look something like this now:
+To check, you App.jsx file should look something like this now:
 
-```js
+``.jsx
 import Header from "./components/Header";
 import Avatar from "./components/Avatar";
 import Logo from "./components/Logo";
@@ -99,7 +99,7 @@ export default function App() {
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file and the files you are going to create during this exercise.
+- You only have to touch the `./src/App.jsx` file and the files you are going to create during this exercise.
 
 ## Development
 

--- a/sessions/react-props/button/README.md
+++ b/sessions/react-props/button/README.md
@@ -8,13 +8,13 @@ And here is the magic: we can only do this with one button component using props
 
 ### 1. A Simple Button Component
 
-Look at the `./src/App.js` file: the `App` component returns a default heading element that you need to replace with a custom component.
+Look at the `./src/App.jsx` file: the `App` component returns a default heading element that you need to replace with a custom component.
 
 Your task is to write a `Button` component which takes three props `color`, `disabled`, and `text` and renders a button with the given color, text and disabled state.
 
 You can use the following hints as guideline:
 
-- Write a `Button` component inside of the `src/App.js`.
+- Write a `Button` component inside of the `src/App.jsx`.
 
   - It accepts three props: `color`, `disabled`, and `text` (make sure to destructure them).
   - It returns an HTML button element which
@@ -62,7 +62,7 @@ As a last step, let's pass a function as a prop to a component.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-props/demo-end/README.md
+++ b/sessions/react-props/demo-end/README.md
@@ -4,7 +4,7 @@ This demo shows how to use props in React.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-props/demo-start/README.md
+++ b/sessions/react-props/demo-start/README.md
@@ -4,7 +4,7 @@ This demo shows how to use props in React.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 - You find the end point for this demo in `sessions/react-props/demo-end`.
 
 ## Development

--- a/sessions/react-props/greeting/README.md
+++ b/sessions/react-props/greeting/README.md
@@ -8,11 +8,11 @@ Let us use `props` to make components totally reusable!
 
 ### Create a Component with props
 
-Look at the `./src/App.js` file: the `App` component returns a default heading element. Replace this element with a custom `Greeting` component, which renders a greeting according to its props.
+Look at the `./src/App.jsx` file: the `App` component returns a default heading element. Replace this element with a custom `Greeting` component, which renders a greeting according to its props.
 
 You can use the following hints as guideline:
 
-- Write the `Greeting` component inside of the `src/App.js`.
+- Write the `Greeting` component inside of the `src/App.jsx`.
   - It accepts a prop called `name` (make sure to destructure it).
   - It returns an HTML element and uses the `name` prop to render "Hello, [name]!";
 - Inside of the return statement of your `App` component, replace the heading with your `Greeting` component and pass it a `name` prop with a value of your choice.
@@ -23,7 +23,7 @@ Update your `Greeting` component to show "Hello, Coach!" if the `name` prop is e
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-props/greeting_solution/README.md
+++ b/sessions/react-props/greeting_solution/README.md
@@ -8,11 +8,11 @@ Let us use `props` to make components totally reusable!
 
 ### Create a Component with props
 
-Look at the `./src/App.js` file: the `App` component returns a default heading element. Replace this element with a custom `Greeting` component, which renders a greeting according to its props.
+Look at the `./src/App.jsx` file: the `App` component returns a default heading element. Replace this element with a custom `Greeting` component, which renders a greeting according to its props.
 
 You can use the following hints as guideline:
 
-- Write the `Greeting` component inside of the `src/App.js`.
+- Write the `Greeting` component inside of the `src/App.jsx`.
   - It accepts a prop called `name` (make sure to destructure it).
   - It returns an HTML element and uses the `name` prop to render "Hello, [name]!";
 - Inside of the return statement of your `App` component, replace the heading with your `Greeting` component and pass it a `name` prop with a value of your choice.
@@ -23,7 +23,7 @@ Update your `Greeting` component to show "Hello, Coach!" if the `name` prop is e
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-props/smiley/README.md
+++ b/sessions/react-props/smiley/README.md
@@ -4,18 +4,18 @@ Props are versatile: you cannot only pass strings or numbers, but a boolean valu
 
 ## Task
 
-Look at the `./src/App.js` file: the `App` component returns a heading which wants to be replaced by a component. Your task is to write a `Smiley` component which renders a smiley depending on a prop called `isHappy`.
+Look at the `./src/App.jsx` file: the `App` component returns a heading which wants to be replaced by a component. Your task is to write a `Smiley` component which renders a smiley depending on a prop called `isHappy`.
 
 You can use the following hints as guideline:
 
-- Write the `Smiley` component inside of the `src/App.js`.
+- Write the `Smiley` component inside of the `src/App.jsx`.
   - It accepts a prop called `isHappy` (make sure to destructure it).
   - It returns a semantic HTML element which renders a happy smiley if `isHappy` is `true` and a sad one if its value is `false`.
 - Inside of the return statement of your `App` component, replace the heading with your `Smiley` component and pass it the `isHappy` prop (– or don't, if you want to display the unhappy smiley).
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-props/smiley_solution/README.md
+++ b/sessions/react-props/smiley_solution/README.md
@@ -4,18 +4,18 @@ Props are versatile: you cannot only pass strings or numbers, but a boolean valu
 
 ## Task
 
-Look at the `./src/App.js` file: the `App` component returns a heading which wants to be replaced by a component. Your task is to write a `Smiley` component which renders a smiley depending on a prop called `isHappy`.
+Look at the `./src/App.jsx` file: the `App` component returns a heading which wants to be replaced by a component. Your task is to write a `Smiley` component which renders a smiley depending on a prop called `isHappy`.
 
 You can use the following hints as guideline:
 
-- Write the `Smiley` component inside of the `src/App.js`.
+- Write the `Smiley` component inside of the `src/App.jsx`.
   - It accepts a prop called `isHappy` (make sure to destructure it).
   - It returns a semantic HTML element which renders a happy smiley if `isHappy` is `true` and a sad one if its value is `false`.
 - Inside of the return statement of your `App` component, replace the heading with your `Smiley` component and pass it the `isHappy` prop (– or don't, if you want to display the unhappy smiley).
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-props/sum/README.md
+++ b/sessions/react-props/sum/README.md
@@ -4,18 +4,18 @@ In this exercise, you will pass two props to a component and and use them to cal
 
 ## Task
 
-Look at the `./src/App.js` file: the `App` component returns a default heading element which you need to replace with a custom component. Your task is to write a `Sum` component which calculates the sum of its two props and renders the result.
+Look at the `./src/App.jsx` file: the `App` component returns a default heading element which you need to replace with a custom component. Your task is to write a `Sum` component which calculates the sum of its two props and renders the result.
 
 You can use the following hints as guideline:
 
-- Write the `Sum` component inside of the `src/App.js`.
+- Write the `Sum` component inside of the `src/App.jsx`.
   - It accepts two props called `valueA` and `valueB` (make sure to destructure them).
   - It returns an HTML element and uses both props to dynamically render something like "1 + 2 = 3" (according to the props).
 - Inside of the return statement of your `App` component, replace the heading with your `Sum` component and pass it both props with values of your choice.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-props/sum_solution/README.md
+++ b/sessions/react-props/sum_solution/README.md
@@ -4,18 +4,18 @@ In this exercise, you will pass two props to a component and and use them to cal
 
 ## Task
 
-Look at the `./src/App.js` file: the `App` component returns a default heading element which you need to replace with a custom component. Your task is to write a `Sum` component which calculates the sum of its two props and renders the result.
+Look at the `./src/App.jsx` file: the `App` component returns a default heading element which you need to replace with a custom component. Your task is to write a `Sum` component which calculates the sum of its two props and renders the result.
 
 You can use the following hints as guideline:
 
-- Write the `Sum` component inside of the `src/App.js`.
+- Write the `Sum` component inside of the `src/App.jsx`.
   - It accepts two props called `valueA` and `valueB` (make sure to destructure them).
   - It returns an HTML element and uses both props to dynamically render something like "1 + 2 = 3" (according to the props).
 - Inside of the return statement of your `App` component, replace the heading with your `Sum` component and pass it both props with values of your choice.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-1/box/README.md
+++ b/sessions/react-state-1/box/README.md
@@ -1,6 +1,6 @@
 # React State: Box
 
-In the `./src/App.js` file, there is a button which toggles an `isActive` variable. You can check the console for its value after clicking the button.
+In the `./src/App.jsx` file, there is a button which toggles an `isActive` variable. You can check the console for its value after clicking the button.
 
 Depending on the `isActive` variable, a class called `box--active` is added to the `<div>` which should then change the `<div>`'s color.
 
@@ -32,7 +32,7 @@ Can you explain why this happens?
 ## Notes
 
 - There is no need to change anything in the return statement of the `App` component (except for the bonus task).
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-1/box_solution/README.md
+++ b/sessions/react-state-1/box_solution/README.md
@@ -1,6 +1,6 @@
 # React State: Box
 
-In the [`src/App.js`](./src/App.js) file, there is a button which toggles an `isActive` variable. You can check the console for its value after clicking the button.
+In the [`src/App.jsx`](./src/App.jsx) file, there is a button which toggles an `isActive` variable. You can check the console for its value after clicking the button.
 
 Depending on the `isActive` variable, a class called `box--active` is added to the `<div>` which should then change the `<div>`'s color.
 
@@ -32,7 +32,7 @@ Can you explain why this happens?
 ## Notes
 
 - There is no need to change anything in the return statement of the `App` component (except for the bonus task).
-- You only have to touch the [`src/App.js`](./src/App.js) file.
+- You only have to touch the [`src/App.jsx`](./src/App.jsx) file.
 
 ## Development
 

--- a/sessions/react-state-1/counter/README.md
+++ b/sessions/react-state-1/counter/README.md
@@ -1,6 +1,6 @@
 # React State: Counter
 
-In the `./src/App.js` you'll find the basic building blocks of a counter.
+In the `./src/App.jsx` you'll find the basic building blocks of a counter.
 
 The general idea here is that the counter should count up when the plus button is clicked, and count down when the minus button is clicked.
 
@@ -20,7 +20,7 @@ You can use the following hints as a guideline:
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-1/counter_solution/README.md
+++ b/sessions/react-state-1/counter_solution/README.md
@@ -1,6 +1,6 @@
 # React State: Counter
 
-In the [`src/App.js`](./src/App.js) you'll find the basic building blocks of a counter.
+In the [`src/App.jsx`](./src/App.jsx) you'll find the basic building blocks of a counter.
 
 The general idea here is that the counter should count up when the plus button is clicked, and count down when the minus button is clicked.
 
@@ -20,7 +20,7 @@ You can use the following hints as a guideline:
 
 ## Notes
 
-- You only have to touch the [`src/App.js`](./src/App.js) file.
+- You only have to touch the [`src/App.jsx`](./src/App.jsx) file.
 
 ## Development
 

--- a/sessions/react-state-1/demo-counter-end/README.md
+++ b/sessions/react-state-1/demo-counter-end/README.md
@@ -4,7 +4,7 @@ This is the end state of the demo counter app.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-1/demo-counter-start/README.md
+++ b/sessions/react-state-1/demo-counter-start/README.md
@@ -4,7 +4,7 @@ This is the start state of the demo counter app.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-1/emoji-checker/README.md
+++ b/sessions/react-state-1/emoji-checker/README.md
@@ -1,6 +1,6 @@
 # React State: Emoji Passcode Checker
 
-In the `./src/App.js` file, you can find the building blocks for an emoji passcode checker.
+In the `./src/App.jsx` file, you can find the building blocks for an emoji passcode checker.
 
 Looking at the `validCode` variable, we understand that the code consists of a sequence of three emojis. Each button click should "lock in" one emoji. If the code that was entered matches the passcode, your code will be confirmed as valid. The reset button should reset the code, so you can start over. Toward the bottom of the `App` function you'll find a line that conditionally generates a `p` element as soon as the input code matches the `validCode` declared at top of the function.
 
@@ -15,7 +15,7 @@ You can use the following hints as a guideline:
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-1/emoji-checker_solution/README.md
+++ b/sessions/react-state-1/emoji-checker_solution/README.md
@@ -1,6 +1,6 @@
 # React State: Emoji Passcode Checker
 
-In the [`src/App.js`](./src/App.js) file, you can find the building blocks for an emoji passcode checker.
+In the [`src/App.jsx`](./src/App.jsx) file, you can find the building blocks for an emoji passcode checker.
 
 Looking at the `validCode` variable, we understand that the code consists of a sequence of three emojis. Each button click should "lock in" one emoji. If the code that was entered matches the passcode, your code will be confirmed as valid. The reset button should reset the code, so you can start over. Toward the bottom of the `App` function you'll find a line that conditionally generates a `p` element as soon as the input code matches the `validCode` declared at top of the function.
 
@@ -16,7 +16,7 @@ You can use the following hints as a guideline:
 
 ## Notes
 
-- You only have to touch the [`src/App.js`](./src/App.js) file.
+- You only have to touch the [`src/App.jsx`](./src/App.jsx) file.
 
 ## Development
 

--- a/sessions/react-state-2/colored-number/README.md
+++ b/sessions/react-state-2/colored-number/README.md
@@ -1,14 +1,14 @@
 # React State 2: Colored Number
 
-This challenge provides a `./src/components/Counter.js`component with two buttons which shall increment or decrement a count.
+This challenge provides a `./src/components/Counter.jsx`component with two buttons which shall increment or decrement a count.
 
-This count is then used by the `./src/components/ColoredNumber.js` component to display the actual number while its color is depending on the value.
+This count is then used by the `./src/components/ColoredNumber.jsx` component to display the actual number while its color is depending on the value.
 
 For now, however, clicking the buttons doesn't change anything. Let's use state to fix that.
 
 ## Task
 
-Refactor the `./src/components/Counter.js` component so that it updates the displayed number when clicking a button.
+Refactor the `./src/components/Counter.jsx` component so that it updates the displayed number when clicking a button.
 
 You can use the following hints as guideline:
 
@@ -18,7 +18,7 @@ You can use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/components/Counter.js` file.
+- You only have to touch the `./src/components/Counter.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/colored-number_solution/README.md
+++ b/sessions/react-state-2/colored-number_solution/README.md
@@ -1,14 +1,14 @@
 # React State 2: Colored Number
 
-This challenge provides a `./src/components/Counter.js`component with two buttons which shall increment or decrement a count.
+This challenge provides a `./src/components/Counter.jsx`component with two buttons which shall increment or decrement a count.
 
-This count is then used by the `./src/components/ColoredNumber.js` component to display the actual number while its color is depending on the value.
+This count is then used by the `./src/components/ColoredNumber.jsx` component to display the actual number while its color is depending on the value.
 
 For now, however, clicking the buttons doesn't change anything. Let's use state to fix that.
 
 ## Task
 
-Refactor the `./src/components/Counter.js` component so that it updates the displayed number when clicking a button.
+Refactor the `./src/components/Counter.jsx` component so that it updates the displayed number when clicking a button.
 
 You can use the following hints as guideline:
 
@@ -18,7 +18,7 @@ You can use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/components/Counter.js` file.
+- You only have to touch the `./src/components/Counter.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/conditional-usestate/README.md
+++ b/sessions/react-state-2/conditional-usestate/README.md
@@ -4,14 +4,14 @@ Click the button "Show Message" to render a hidden message to the UI. The App wi
 
 ## Task
 
-Switch to the `./src/App.js` file and make yourself familiar with the App.
+Switch to the `./src/App.jsx` file and make yourself familiar with the App.
 
-After that, fix the error in the `./src/App.js` file. If you need a clue, search the internet for the eslint rule or the error message.
+After that, fix the error in the `./src/App.jsx` file. If you need a clue, search the internet for the eslint rule or the error message.
 
 ## Notes
 
 - If you are wondering about your solution: yes, it is that easy!
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/conditional-usestate_solution/README.md
+++ b/sessions/react-state-2/conditional-usestate_solution/README.md
@@ -4,14 +4,14 @@ Click the button "Show Message" to render a hidden message to the UI. The App wi
 
 ## Task
 
-Switch to the `./src/App.js` file and make yourself familiar with the App.
+Switch to the `./src/App.jsx` file and make yourself familiar with the App.
 
-After that, fix the error in the `./src/App.js` file. If you need a clue, search the internet for the eslint rule or the error message.
+After that, fix the error in the `./src/App.jsx` file. If you need a clue, search the internet for the eslint rule or the error message.
 
 ## Notes
 
 - If you are wondering about your solution: yes, it is that easy!
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/demo-end/README.md
+++ b/sessions/react-state-2/demo-end/README.md
@@ -5,8 +5,8 @@ This is the end state of the demo app.
 ## Notes
 
 - You only have to touch this files:
-  - `./src/App.js`
-  - `./src/components/SearchForm.js`
+  - `./src/App.jsx`
+  - `./src/components/SearchForm.jsx`
 
 ## Development
 

--- a/sessions/react-state-2/demo-start/README.md
+++ b/sessions/react-state-2/demo-start/README.md
@@ -5,8 +5,8 @@ This is the start state of the demo app.
 ## Notes
 
 - You only have to touch this files:
-  - `./src/App.js`
-  - `./src/components/SearchForm.js`
+  - `./src/App.jsx`
+  - `./src/components/SearchForm.jsx`
 
 ## Development
 

--- a/sessions/react-state-2/favourite-holiday/README.md
+++ b/sessions/react-state-2/favourite-holiday/README.md
@@ -1,12 +1,12 @@
 # React State 2: Favourite Holiday
 
-In the `./src/App.js` file, there is a form in which you can enter your favourite holiday and its respective date. Below the form, the submitted data should be displayed.
+In the `./src/App.jsx` file, there is a form in which you can enter your favourite holiday and its respective date. Below the form, the submitted data should be displayed.
 
 Unfortunately, the form is not working correctly. Let's fix that!
 
 ## Task
 
-Switch to the `./src/App.js` file and refactor the `handleSubmit` function so that
+Switch to the `./src/App.jsx` file and refactor the `handleSubmit` function so that
 
 1. the `App` component has access to the submitted data,
 2. the submitted data is dynamically rendered in the respective output fields below the form.
@@ -23,7 +23,7 @@ When submitting the form, the form fields should be reset and the `holiday` fiel
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/favourite-holiday_solution/README.md
+++ b/sessions/react-state-2/favourite-holiday_solution/README.md
@@ -1,12 +1,12 @@
 # React State 2: Favourite Holiday
 
-In the `./src/App.js` file, there is a form in which you can enter your favourite holiday and its respective date. Below the form, the submitted data should be displayed.
+In the `./src/App.jsx` file, there is a form in which you can enter your favourite holiday and its respective date. Below the form, the submitted data should be displayed.
 
 Unfortunately, the form is not working correctly. Let's fix that!
 
 ## Task
 
-Switch to the `./src/App.js` file and refactor the `handleSubmit` function so that
+Switch to the `./src/App.jsx` file and refactor the `handleSubmit` function so that
 
 1. the `App` component has access to the submitted data,
 2. the submitted data is dynamically rendered in the respective output fields below the form.
@@ -23,7 +23,7 @@ When submitting the form, the form fields should be reset and the `holiday` fiel
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/personal-details/README.md
+++ b/sessions/react-state-2/personal-details/README.md
@@ -8,7 +8,7 @@ Unfortunately, hitting the submit button does not do anything. Since you are loo
 
 ### 1. Setting State on Submit
 
-Let's start by fixing the submit event first. Switch to the `./src/components/Form.js` file; there already are two states called `name` and `email` and a `handleSubmit` function.
+Let's start by fixing the submit event first. Switch to the `./src/components/Form.jsx` file; there already are two states called `name` and `email` and a `handleSubmit` function.
 
 1. Extend the `handleSubmit` function to set the `name` and `email` state to its corresponding form field values.
 2. Reset the form after submit.
@@ -17,7 +17,7 @@ Let's start by fixing the submit event first. Switch to the `./src/components/Fo
 
 🎉 Congratulations, the submit works and the data is stored in state variables!
 
-Unfortunately, the submitted details are not dynamically displayed in the [`App` component](./src/App.js) because the state only lives in the `Form` component.
+Unfortunately, the submitted details are not dynamically displayed in the [`App` component](./src/App.jsx) because the state only lives in the `Form` component.
 
 Refactor the code so that
 
@@ -36,7 +36,7 @@ You can use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/App.js` and `./src/components/Form.js` file.
+- You only have to touch the `./src/App.jsx` and `./src/components/Form.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/personal-details_solution/README.md
+++ b/sessions/react-state-2/personal-details_solution/README.md
@@ -8,7 +8,7 @@ Unfortunately, hitting the submit button does not do anything. Since you are loo
 
 ### 1. Setting State on Submit
 
-Let's start by fixing the submit event first. Switch to the `./src/components/Form.js` file; there already are two states called `name` and `email` and a `handleSubmit` function.
+Let's start by fixing the submit event first. Switch to the `./src/components/Form.jsx` file; there already are two states called `name` and `email` and a `handleSubmit` function.
 
 1. Extend the `handleSubmit` function to set the `name` and `email` state to its corresponding form field values.
 2. Reset the form after submit.
@@ -17,7 +17,7 @@ Let's start by fixing the submit event first. Switch to the `./src/components/Fo
 
 🎉 Congratulations, the submit works and the data is stored in state variables!
 
-Unfortunately, the submitted details are not dynamically displayed in the [`App` component](./src/App.js) because the state only lives in the `Form` component.
+Unfortunately, the submitted details are not dynamically displayed in the [`App` component](./src/App.jsx) because the state only lives in the `Form` component.
 
 Refactor the code so that
 
@@ -36,7 +36,7 @@ You can use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/App.js` and `./src/components/Form.js` file.
+- You only have to touch the `./src/App.jsx` and `./src/components/Form.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/table-reservation/README.md
+++ b/sessions/react-state-2/table-reservation/README.md
@@ -2,9 +2,9 @@
 
 In this challenge, there is an app to reserve a table at a restaurant.
 
-Have a look at the [`Counter Component`](./src/components/Counter.js): there is a state which gets updated when the buttons are clicked.
+Have a look at the [`Counter Component`](./src/components/Counter.jsx): there is a state which gets updated when the buttons are clicked.
 
-In the `./src/App.js` file, however, there is a sentence saying "You are going to reserve a table for 2 people." The number should not be hard coded, but equal the current people count and need to be updated on every button click.
+In the `./src/App.jsx` file, however, there is a sentence saying "You are going to reserve a table for 2 people." The number should not be hard coded, but equal the current people count and need to be updated on every button click.
 
 ## Task
 
@@ -26,7 +26,7 @@ You can use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/App.js` and `./src/components/Counter.js` file.
+- You only have to touch the `./src/App.jsx` and `./src/components/Counter.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/table-reservation_solution/README.md
+++ b/sessions/react-state-2/table-reservation_solution/README.md
@@ -2,9 +2,9 @@
 
 In this challenge, there is an app to reserve a table at a restaurant.
 
-Have a look at the [`Counter Component`](./src/components/Counter.js): there is a state which gets updated when the buttons are clicked.
+Have a look at the [`Counter Component`](./src/components/Counter.jsx): there is a state which gets updated when the buttons are clicked.
 
-In the `./src/App.js` file, however, there is a sentence saying "You are going to reserve a table for 2 people." The number should not be hard coded, but equal the current people count and need to be updated on every button click.
+In the `./src/App.jsx` file, however, there is a sentence saying "You are going to reserve a table for 2 people." The number should not be hard coded, but equal the current people count and need to be updated on every button click.
 
 ## Task
 
@@ -26,7 +26,7 @@ You can use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/App.js` and `./src/components/Counter.js` file.
+- You only have to touch the `./src/App.jsx` and `./src/components/Counter.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/triple-count/README.md
+++ b/sessions/react-state-2/triple-count/README.md
@@ -1,6 +1,6 @@
 # React State 2: Triple Count
 
-The `./src/components/Counter.js` file offers a `count` state, a button to increment this state and a `handleIncrement` function.
+The `./src/components/Counter.jsx` file offers a `count` state, a button to increment this state and a `handleIncrement` function.
 
 Clicking the button should increment the `count` by 3. Currently, however, it's incremented by 1, although the `handleIncrement` function calls `setCount(count + 1)` three times.
 
@@ -18,7 +18,7 @@ You can use the following hint as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/components/Counter.js` file.
+- You only have to touch the `./src/components/Counter.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-2/triple-count_solution/README.md
+++ b/sessions/react-state-2/triple-count_solution/README.md
@@ -1,6 +1,6 @@
 # React State 2: Triple Count
 
-The `./src/components/Counter.js` file offers a `count` state, a button to increment this state and a `handleIncrement` function.
+The `./src/components/Counter.jsx` file offers a `count` state, a button to increment this state and a `handleIncrement` function.
 
 Clicking the button should increment the `count` by 3. Currently, however, it's incremented by 1, although the `handleIncrement` function calls `setCount(count + 1)` three times.
 
@@ -18,7 +18,7 @@ You can use the following hint as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/components/Counter.js` file.
+- You only have to touch the `./src/components/Counter.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-3/adding-animals/README.md
+++ b/sessions/react-state-3/adding-animals/README.md
@@ -1,6 +1,6 @@
 # React State 3: Adding Animals
 
-In the `./src/App.js` file, there is an `animals` state used to render a list of `initialAnimals`. There is also a [`Form`](./src/components/Form/index.js) component which already handles the submit event and the data.
+In the `./src/App.jsx` file, there is an `animals` state used to render a list of `initialAnimals`. There is also a [`Form`](./src/components/Form/index.jsx) component which already handles the submit event and the data.
 
 Currently, the only thing not working is the state update.
 
@@ -13,15 +13,15 @@ Currently, the only thing not working is the state update.
 
 You can use the following hints as guideline:
 
-- Look at `./src/components/Form/index.js`; what kind of data is lifted up to the `App`?
-- In the `./src/App.js` file, there is a `handleAddAnimal` function which only calls a `console.log`.
+- Look at `./src/components/Form/index.jsx`; what kind of data is lifted up to the `App`?
+- In the `./src/App.jsx` file, there is a `handleAddAnimal` function which only calls a `console.log`.
 - Replace the `console.log` with the state setter function; pass it a copy of the previous state and add the submitted animal at the end of this new state.
 
 Congratulations, you can now add a new animal to the state and it is rendered!
 
 ### Adding a unique identifier
 
-There is, however, a warning regarding the `key` prop in list items. This happens becaus newly added items currently don't have an `id` to be used by the `./src/components/List/index.js` component. There is a package called `uid` already installed to fix this.
+There is, however, a warning regarding the `key` prop in list items. This happens becaus newly added items currently don't have an `id` to be used by the `./src/components/List/index.jsx` component. There is a package called `uid` already installed to fix this.
 
 - In your `App`, import `uid` via `import { uid } from "uid";`.
 - A new animal is added inside of the `handleAddAnimal` function, which is where you need to add the id.
@@ -31,7 +31,7 @@ There is, however, a warning regarding the `key` prop in list items. This happen
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-3/adding-animals_solution/README.md
+++ b/sessions/react-state-3/adding-animals_solution/README.md
@@ -1,6 +1,6 @@
 # React State 3: Adding Animals
 
-In the `./src/App.js` file, there is an `animals` state used to render a list of `initialAnimals`. There is also a [`Form`](./src/components/Form/index.js) component which already handles the submit event and the data.
+In the `./src/App.jsx` file, there is an `animals` state used to render a list of `initialAnimals`. There is also a [`Form`](./src/components/Form/index.jsx) component which already handles the submit event and the data.
 
 Currently, the only thing not working is the state update.
 
@@ -13,15 +13,15 @@ Currently, the only thing not working is the state update.
 
 You can use the following hints as guideline:
 
-- Look at `./src/components/Form/index.js`; what kind of data is lifted up to the `App`?
-- In the `./src/App.js` file, there is a `handleAddAnimal` function which only calls a `console.log`.
+- Look at `./src/components/Form/index.jsx`; what kind of data is lifted up to the `App`?
+- In the `./src/App.jsx` file, there is a `handleAddAnimal` function which only calls a `console.log`.
 - Replace the `console.log` with the state setter function; pass it a copy of the previous state and add the submitted animal at the end of this new state.
 
 Congratulations, you can now add a new animal to the state and it is rendered!
 
 ### Adding a unique identifier
 
-There is, however, a warning regarding the `key` prop in list items. This happens becaus newly added items currently don't have an `id` to be used by the `./src/components/List/index.js` component. There is a package called `uid` already installed to fix this.
+There is, however, a warning regarding the `key` prop in list items. This happens becaus newly added items currently don't have an `id` to be used by the `./src/components/List/index.jsx` component. There is a package called `uid` already installed to fix this.
 
 - In your `App`, import `uid` via `import { uid } from "uid";`.
 - A new animal is added inside of the `handleAddAnimal` function, which is where you need to add the id.
@@ -31,7 +31,7 @@ There is, however, a warning regarding the `key` prop in list items. This happen
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-3/demo-end/README.md
+++ b/sessions/react-state-3/demo-end/README.md
@@ -4,7 +4,7 @@ This is the end state of the demo app.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-3/demo-start/README.md
+++ b/sessions/react-state-3/demo-start/README.md
@@ -6,7 +6,7 @@ This is the start state of the demo app.
 
 TO DO:
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-3/journal-app-form/README.md
+++ b/sessions/react-state-3/journal-app-form/README.md
@@ -49,7 +49,7 @@ Your new journal entry needs a date.
 - Create a string containing the date in the desired format with the snippet below.
 - Add the key `date` to the object describing the new entry.
 
-```js
+``.jsx
 const date = new Date().toLocaleDateString("en-us", { dateStyle: "medium" });
 ```
 

--- a/sessions/react-state-3/tags/README.md
+++ b/sessions/react-state-3/tags/README.md
@@ -1,8 +1,8 @@
 # React State 3: Tags
 
-In the `./src/App.js` file, there is a `tags` state passed to the [`List`](./src/components/List/index.js) component. Each tag has a delete button.
+In the `./src/App.jsx` file, there is a `tags` state passed to the [`List`](./src/components/List/index.jsx) component. Each tag has a delete button.
 
-There is also a [`Form`](./src/components/Form/index.js) component which already handles the submit event and the data.
+There is also a [`Form`](./src/components/Form/index.jsx) component which already handles the submit event and the data.
 
 Currently, it's not possible to add or remove a tag from state.
 
@@ -33,7 +33,7 @@ You can use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-state-3/tags_solution/README.md
+++ b/sessions/react-state-3/tags_solution/README.md
@@ -1,8 +1,8 @@
 # React State 3: Tags
 
-In the `./src/App.js` file, there is a `tags` state passed to the [`List`](./src/components/List/index.js) component. Each tag has a delete button.
+In the `./src/App.jsx` file, there is a `tags` state passed to the [`List`](./src/components/List/index.jsx) component. Each tag has a delete button.
 
-There is also a [`Form`](./src/components/Form/index.js) component which already handles the submit event and the data.
+There is also a [`Form`](./src/components/Form/index.jsx) component which already handles the submit event and the data.
 
 Currently, it's not possible to add or remove a tag from state.
 
@@ -33,7 +33,7 @@ You can use the following hints as guideline:
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-with-arrays/demo-end/README.md
+++ b/sessions/react-with-arrays/demo-end/README.md
@@ -4,7 +4,7 @@ This is the end state of the demo Pokemon app.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-with-arrays/demo-start/README.md
+++ b/sessions/react-with-arrays/demo-start/README.md
@@ -4,7 +4,7 @@ This is the end state of the demo Pokemon app.
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-with-arrays/fruits/README.md
+++ b/sessions/react-with-arrays/fruits/README.md
@@ -1,6 +1,6 @@
 # React Arrays: Fruits
 
-For now, the `./src/App.js` file uses a `Card` component to render the text "banana". This is easy to handle if you only have a single use case.
+For now, the `./src/App.jsx` file uses a `Card` component to render the text "banana". This is easy to handle if you only have a single use case.
 
 Most often, however, you have an array of objects and want to dynamically render a component (like `Card`) for each of these objects.
 

--- a/sessions/react-with-arrays/fruits_solution/README.md
+++ b/sessions/react-with-arrays/fruits_solution/README.md
@@ -1,6 +1,6 @@
 # React Arrays: Fruits
 
-For now, the `./src/App.js` file uses a `Card` component to render the text "banana". This is easy to handle if you only have a single use case.
+For now, the `./src/App.jsx` file uses a `Card` component to render the text "banana". This is easy to handle if you only have a single use case.
 
 Most often, however, you have an array of objects and want to dynamically render a component (like `Card`) for each of these objects.
 

--- a/sessions/react-with-arrays/journal-app-entries-array/README.md
+++ b/sessions/react-with-arrays/journal-app-entries-array/README.md
@@ -8,7 +8,7 @@ Locate the component that renders your journal entries. Here it's called `Entrie
 
 Copy the `entries` array below into the component that renders your journal entries.
 
-```js
+``.jsx
 const entries = [
   {
     id: 1000,

--- a/sessions/react-with-arrays/journal-app-entries-array_solution/README.md
+++ b/sessions/react-with-arrays/journal-app-entries-array_solution/README.md
@@ -8,7 +8,7 @@ Locate the component that renders your journal entries. Here it's called `Entrie
 
 Copy the `entries` array below into the component that renders your journal entries.
 
-```js
+``.jsx
 const entries = [
   {
     id: 1000,

--- a/sessions/react-with-arrays/users/README.md
+++ b/sessions/react-with-arrays/users/README.md
@@ -1,6 +1,6 @@
 # React Arrays: Users
 
-The `./src/App.js` file should dynamically display a card for each of the nine `USERS` imported from the `db.js` file.
+The `./src/App.jsx` file should dynamically display a card for each of the nine `USERS` imported from the `db.jsx` file.
 
 For now, however, there is only one card. Let's fix this with our newly acquired knowledge about arrays in React.
 
@@ -16,7 +16,7 @@ After that, you can implement two more features to make the user overview even m
 
 ## Notes
 
-- You only have to touch the files `./src/App.js`, `./src/Card.js`, and `./src/Tag.js`.
+- You only have to touch the files `./src/App.jsx`, `./src/Card.jsx`, and `./src/Tag.jsx`.
 
 ## Development
 

--- a/sessions/react-with-arrays/users_solution/README.md
+++ b/sessions/react-with-arrays/users_solution/README.md
@@ -1,6 +1,6 @@
 # React Arrays: Users
 
-The `./src/App.js` file should dynamically display a card for each of the nine `USERS` imported from the `db.js` file.
+The `./src/App.jsx` file should dynamically display a card for each of the nine `USERS` imported from the `db.jsx` file.
 
 For now, however, there is only one card. Let's fix this with our newly acquired knowledge about arrays in React.
 
@@ -16,7 +16,7 @@ After that, you can implement two more features to make the user overview even m
 
 ## Notes
 
-- You only have to touch the files `./src/App.js`, `./src/Card.js`, and `./src/Tag.js`.
+- You only have to touch the files `./src/App.jsx`, `./src/Card.jsx`, and `./src/Tag.jsx`.
 
 ## Development
 

--- a/sessions/react-with-local-storage/demo-end/README.md
+++ b/sessions/react-with-local-storage/demo-end/README.md
@@ -3,7 +3,7 @@
 ## Notes
 
 - This is the end version of the demo
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-with-local-storage/demo-start/README.md
+++ b/sessions/react-with-local-storage/demo-start/README.md
@@ -3,7 +3,7 @@
 ## Notes
 
 - This is the start version of the demo
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-with-local-storage/dice/README.md
+++ b/sessions/react-with-local-storage/dice/README.md
@@ -6,7 +6,7 @@ This dice rolling app rolls a die (d6 = six sided die). Now you want to show rec
 
 ### Lifting State Up
 
-Look at the `./src/App.js` and `./src/components/D6Button/index.js` files.
+Look at the `./src/App.jsx` and `./src/components/D6Button/index.jsx` files.
 
 Lift up the `rolls` state into the `App` component.
 
@@ -40,7 +40,7 @@ Install `use-local-storage-state` via npm. Import the `useLocalStorageState` hoo
 
 ## Notes
 
-- You only have to touch the `./src/App.js` and `./src/components/D6Button/index.js` files.
+- You only have to touch the `./src/App.jsx` and `./src/components/D6Button/index.jsx` files.
 
 ## Development
 

--- a/sessions/react-with-local-storage/dice_solution/README.md
+++ b/sessions/react-with-local-storage/dice_solution/README.md
@@ -6,7 +6,7 @@ This dice rolling app rolls a die (d6 = six sided die). Now you want to show rec
 
 ### Lifting State Up
 
-Look at the `./src/App.js` and `./src/components/D6Button/index.js` files.
+Look at the `./src/App.jsx` and `./src/components/D6Button/index.jsx` files.
 
 Lift up the `rolls` state into the `App` component.
 
@@ -40,7 +40,7 @@ Install `use-local-storage-state` via npm. Import the `useLocalStorageState` hoo
 
 ## Notes
 
-- You only have to touch the `./src/App.js` and `./src/components/D6Button/index.js` files.
+- You only have to touch the `./src/App.jsx` and `./src/components/D6Button/index.jsx` files.
 
 ## Development
 

--- a/sessions/react-with-local-storage/stored-note/README.md
+++ b/sessions/react-with-local-storage/stored-note/README.md
@@ -4,15 +4,15 @@ The contents of this notepad are lost when you refresh the page. Make it persist
 
 ## Task
 
-Switch to the `./src/App.js` file and replace both `useState` hooks with `useLocalStorageState` hooks to make the notepad and the font selection persistent. The `use-local-storage-state` package is already installed. Import it like this:
+Switch to the `./src/App.jsx` file and replace both `useState` hooks with `useLocalStorageState` hooks to make the notepad and the font selection persistent. The `use-local-storage-state` package is already installed. Import it like this:
 
-```js
+``.jsx
 import useLocalStorageState from "use-local-storage-state";
 ```
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 

--- a/sessions/react-with-local-storage/stored-note_solution/README.md
+++ b/sessions/react-with-local-storage/stored-note_solution/README.md
@@ -4,15 +4,15 @@ The contents of this notepad are lost when you refresh the page. Make it persist
 
 ## Task
 
-Switch to the `./src/App.js` file and replace both `useState` hooks with `useLocalStorageState` hooks to make the notepad and the font selection persistent. The `use-local-storage-state` package is already installed. Import it like this:
+Switch to the `./src/App.jsx` file and replace both `useState` hooks with `useLocalStorageState` hooks to make the notepad and the font selection persistent. The `use-local-storage-state` package is already installed. Import it like this:
 
-```js
+``.jsx
 import useLocalStorageState from "use-local-storage-state";
 ```
 
 ## Notes
 
-- You only have to touch the `./src/App.js` file.
+- You only have to touch the `./src/App.jsx` file.
 
 ## Development
 


### PR DESCRIPTION
I discovered that the README.md files of the vite projects often referred to components or files with the '.js' Ending like 'You only have to touch the App.js'. This PR substitutes the '.js' with '.jsx' in the corresponding READMEs.