### PR TITLE
Fix name on package js

### DIFF
--- a/sessions/js-array-methods/demo-end/package.json
+++ b/sessions/js-array-methods/demo-end/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "js-array-methods_demo-start",
+  "name": "js-array-methods_demo-end",
   "version": "0.0.0-unreleased",
-  "description": "Start of Demo for JS Array Methods Session",
+  "description": "End of Demo for JS Array Methods Session",
   "main": "index.html",
   "scripts": {
     "lint": "npx -y eslint@latest .",


### PR DESCRIPTION
Fix name in package json.
When doing for the first time `npm i` this error `npm ERR! code EDUPLICATEWORKSPACE must not have multiple workspaces with the same name` was happening due to the name was the same as demo start